### PR TITLE
feat: implement inquiry system (Sprint 8)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@prisma/client": "^6.3.0",
+    "@sendgrid/mail": "^8.1.4",
     "bcryptjs": "^3.0.3",
     "cloudinary": "^2.9.0",
     "cors": "^2.8.5",

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -267,8 +267,8 @@ model CollectionArtwork {
 // ============================================================================
 
 model Inquiry {
-  id        String @id @default(cuid())
-  userId    String
+  id        String  @id @default(cuid())
+  userId    String?
   artworkId String
 
   // Contact info (in case user is not registered)
@@ -289,7 +289,7 @@ model Inquiry {
   updatedAt DateTime @updatedAt
 
   // Relations
-  user    User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user    User?   @relation(fields: [userId], references: [id], onDelete: Cascade)
   artwork Artwork @relation(fields: [artworkId], references: [id], onDelete: Cascade)
 
   @@index([userId])

--- a/apps/api/src/config/environment.ts
+++ b/apps/api/src/config/environment.ts
@@ -33,6 +33,7 @@ export const config = {
   email: {
     sendgridApiKey: process.env.SENDGRID_API_KEY || '',
     fromEmail: process.env.FROM_EMAIL || 'noreply@artspot.com',
+    staffEmail: process.env.STAFF_EMAIL || '',
   },
 } as const;
 

--- a/apps/api/src/controllers/inquiry.controller.ts
+++ b/apps/api/src/controllers/inquiry.controller.ts
@@ -1,0 +1,103 @@
+import { Request, Response, NextFunction } from 'express';
+import { inquiryService } from '../services/inquiry.service';
+import {
+  createInquirySchema,
+  respondInquirySchema,
+  listInquiriesQuerySchema,
+} from '../validators/inquiry.validator';
+import { AppError } from '../middleware/error-handler';
+
+export class InquiryController {
+  /**
+   * POST /inquiries
+   * Submit an inquiry (guest or authenticated)
+   */
+  async create(req: Request, res: Response, next: NextFunction) {
+    try {
+      const userId = (req as any).userId as string | undefined;
+      const data = createInquirySchema.parse(req.body);
+
+      const inquiry = await inquiryService.create(data, userId);
+
+      res.status(201).json({
+        success: true,
+        data: inquiry,
+      });
+    } catch (error) {
+      if (error instanceof Error && error.message === 'Artwork not found') {
+        return next(new AppError('Artwork not found', 404));
+      }
+      next(error);
+    }
+  }
+
+  /**
+   * GET /inquiries
+   * List the authenticated user's own inquiries
+   */
+  async listUserInquiries(req: Request, res: Response, next: NextFunction) {
+    try {
+      const userId = (req as any).userId as string;
+      const query = listInquiriesQuerySchema.parse(req.query);
+
+      const result = await inquiryService.listUserInquiries(userId, query);
+
+      res.json({
+        success: true,
+        ...result,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /inquiries/admin
+   * List all inquiries (admin/staff only) with filters
+   */
+  async listAll(req: Request, res: Response, next: NextFunction) {
+    try {
+      const query = listInquiriesQuerySchema.parse(req.query);
+
+      const result = await inquiryService.listAll(query);
+
+      res.json({
+        success: true,
+        ...result,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * PATCH /inquiries/:id
+   * Respond to or close an inquiry (admin/staff only)
+   */
+  async respond(req: Request, res: Response, next: NextFunction) {
+    try {
+      const inquiryId = req.params.id as string;
+      const staffUserId = (req as any).userId as string;
+      const data = respondInquirySchema.parse(req.body);
+
+      const inquiry = await inquiryService.respond(inquiryId, staffUserId, data);
+
+      res.json({
+        success: true,
+        data: inquiry,
+      });
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.message === 'Inquiry not found') {
+          return next(new AppError('Inquiry not found', 404));
+        }
+        if (error.message.startsWith('Cannot transition')) {
+          return next(new AppError(error.message, 400));
+        }
+      }
+      next(error);
+    }
+  }
+}
+
+export const inquiryController = new InquiryController();

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -19,6 +19,7 @@ import artistsRouter from './routes/artists';
 import collectionsRouter from './routes/collections';
 import authRouter from './routes/auth';
 import favoritesRouter from './routes/favorites';
+import inquiriesRouter from './routes/inquiries';
 import { initializeCloudinary } from './config/cloudinary';
 
 // Initialize Cloudinary AFTER env vars are loaded
@@ -56,6 +57,7 @@ app.use('/artworks', artworksRouter);
 app.use('/artists', artistsRouter);
 app.use('/collections', collectionsRouter);
 app.use('/favorites', favoritesRouter);
+app.use('/inquiries', inquiriesRouter);
 
 // 404 handler
 app.use('*', (req, res) => {

--- a/apps/api/src/routes/inquiries.ts
+++ b/apps/api/src/routes/inquiries.ts
@@ -1,0 +1,33 @@
+import { Router } from 'express';
+import { inquiryController } from '../controllers/inquiry.controller';
+import { authenticate, optionalAuth, authorize } from '../middleware/auth';
+
+const router = Router();
+
+// Submit inquiry (guest or authenticated)
+// POST /inquiries  { artworkId, name, email, phone?, message }
+router.post('/', optionalAuth, inquiryController.create.bind(inquiryController));
+
+// List authenticated user's own inquiries
+// GET /inquiries?page=1&limit=20&status=PENDING
+router.get('/', authenticate, inquiryController.listUserInquiries.bind(inquiryController));
+
+// List all inquiries (admin/staff only)
+// GET /inquiries/admin?page=1&limit=20&status=PENDING&search=john
+router.get(
+  '/admin',
+  authenticate,
+  authorize('ADMIN', 'GALLERY_STAFF'),
+  inquiryController.listAll.bind(inquiryController)
+);
+
+// Respond to or update inquiry status (admin/staff only)
+// PATCH /inquiries/:id  { response?, status? }
+router.patch(
+  '/:id',
+  authenticate,
+  authorize('ADMIN', 'GALLERY_STAFF'),
+  inquiryController.respond.bind(inquiryController)
+);
+
+export default router;

--- a/apps/api/src/services/email.service.ts
+++ b/apps/api/src/services/email.service.ts
@@ -1,0 +1,103 @@
+import sgMail from '@sendgrid/mail';
+import { config } from '../config/environment';
+
+const isConfigured = !!config.email.sendgridApiKey;
+
+if (isConfigured) {
+  sgMail.setApiKey(config.email.sendgridApiKey);
+}
+
+interface InquiryEmailData {
+  inquiryId: string;
+  customerName: string;
+  customerEmail: string;
+  customerPhone?: string | null;
+  message: string;
+  artworkTitle: string;
+  artworkSlug: string;
+}
+
+export class EmailService {
+  /**
+   * Notify staff about a new inquiry.
+   * Skips silently when SendGrid is not configured (safe for dev).
+   */
+  async sendNewInquiryNotification(data: InquiryEmailData) {
+    if (!isConfigured || !config.email.staffEmail) return;
+
+    const msg = {
+      to: config.email.staffEmail,
+      from: config.email.fromEmail,
+      subject: `New Inquiry: ${data.artworkTitle}`,
+      text: [
+        `New inquiry received for "${data.artworkTitle}".`,
+        '',
+        `From: ${data.customerName} (${data.customerEmail})`,
+        data.customerPhone ? `Phone: ${data.customerPhone}` : '',
+        '',
+        'Message:',
+        data.message,
+        '',
+        `Manage: ${config.apiUrl.replace(/\/api$/, '')}/admin/inquiries`,
+      ]
+        .filter(Boolean)
+        .join('\n'),
+      html: `
+        <h2>New Inquiry: ${data.artworkTitle}</h2>
+        <p><strong>From:</strong> ${data.customerName} &lt;${data.customerEmail}&gt;</p>
+        ${data.customerPhone ? `<p><strong>Phone:</strong> ${data.customerPhone}</p>` : ''}
+        <hr />
+        <p><strong>Message:</strong></p>
+        <p>${data.message.replace(/\n/g, '<br />')}</p>
+      `,
+    };
+
+    try {
+      await sgMail.send(msg);
+    } catch (error) {
+      console.error('Failed to send new inquiry notification:', error);
+    }
+  }
+
+  /**
+   * Notify customer that staff has responded to their inquiry.
+   * Skips silently when SendGrid is not configured.
+   */
+  async sendInquiryResponseNotification(
+    data: InquiryEmailData & { response: string }
+  ) {
+    if (!isConfigured) return;
+
+    const msg = {
+      to: data.customerEmail,
+      from: config.email.fromEmail,
+      subject: `Re: Your Inquiry About "${data.artworkTitle}"`,
+      text: [
+        `Dear ${data.customerName},`,
+        '',
+        `Thank you for your interest in "${data.artworkTitle}". Our team has responded to your inquiry:`,
+        '',
+        data.response,
+        '',
+        'Best regards,',
+        'The ArtSpot Team',
+      ].join('\n'),
+      html: `
+        <p>Dear ${data.customerName},</p>
+        <p>Thank you for your interest in &ldquo;${data.artworkTitle}&rdquo;. Our team has responded to your inquiry:</p>
+        <blockquote style="border-left: 3px solid #ccc; padding-left: 12px; margin: 16px 0; color: #555;">
+          ${data.response.replace(/\n/g, '<br />')}
+        </blockquote>
+        <p>Best regards,<br />The ArtSpot Team</p>
+      `,
+    };
+
+    try {
+      await sgMail.send(msg);
+    } catch (error) {
+      console.error('Failed to send inquiry response notification:', error);
+    }
+  }
+}
+
+export const emailService = new EmailService();

--- a/apps/api/src/services/inquiry.service.ts
+++ b/apps/api/src/services/inquiry.service.ts
@@ -1,0 +1,204 @@
+import { Prisma } from '@prisma/client';
+import { prisma } from '../config/database';
+import type { CreateInquiryInput, RespondInquiryInput, ListInquiriesQuery } from '../validators/inquiry.validator';
+import { emailService } from './email.service';
+
+const VALID_TRANSITIONS: Record<string, string[]> = {
+  PENDING: ['RESPONDED', 'CLOSED'],
+  RESPONDED: ['CLOSED'],
+  CLOSED: [],
+};
+
+export class InquiryService {
+  /**
+   * Create a new inquiry on an artwork.
+   * userId is optional — guests can submit without an account.
+   */
+  async create(data: CreateInquiryInput, userId?: string) {
+    // Verify artwork exists
+    const artwork = await prisma.artwork.findUnique({
+      where: { id: data.artworkId },
+      select: { id: true, title: true },
+    });
+    if (!artwork) {
+      throw new Error('Artwork not found');
+    }
+
+    const inquiry = await prisma.inquiry.create({
+      data: {
+        artworkId: data.artworkId,
+        userId: userId || null,
+        name: data.name,
+        email: data.email,
+        phone: data.phone,
+        message: data.message,
+      },
+      include: {
+        artwork: { select: { id: true, title: true, slug: true } },
+      },
+    });
+
+    // Fire-and-forget email notification to staff
+    void emailService
+      .sendNewInquiryNotification({
+        inquiryId: inquiry.id,
+        customerName: data.name,
+        customerEmail: data.email,
+        customerPhone: data.phone,
+        message: data.message,
+        artworkTitle: artwork.title,
+        artworkSlug: inquiry.artwork.slug,
+      })
+      .catch((err) => console.error('Email notification failed:', err));
+
+    return inquiry;
+  }
+
+  /**
+   * List inquiries for an authenticated user (their own).
+   */
+  async listUserInquiries(userId: string, query: ListInquiriesQuery) {
+    const { page, limit, status, sortBy, sortOrder } = query;
+    const skip = (page - 1) * limit;
+
+    const where: Prisma.InquiryWhereInput = { userId };
+    if (status) where.status = status;
+
+    const [inquiries, total] = await Promise.all([
+      prisma.inquiry.findMany({
+        where,
+        skip,
+        take: limit,
+        orderBy: { [sortBy]: sortOrder },
+        include: {
+          artwork: {
+            select: {
+              id: true,
+              title: true,
+              slug: true,
+              images: { where: { type: 'MAIN' }, take: 1, orderBy: { displayOrder: 'asc' } },
+            },
+          },
+        },
+      }),
+      prisma.inquiry.count({ where }),
+    ]);
+
+    return {
+      data: inquiries,
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }
+
+  /**
+   * List all inquiries (admin/staff). Supports filtering by status and search.
+   */
+  async listAll(query: ListInquiriesQuery) {
+    const { page, limit, status, search, sortBy, sortOrder } = query;
+    const skip = (page - 1) * limit;
+
+    const where: Prisma.InquiryWhereInput = {};
+    if (status) where.status = status;
+    if (search) {
+      where.OR = [
+        { name: { contains: search, mode: 'insensitive' } },
+        { email: { contains: search, mode: 'insensitive' } },
+      ];
+    }
+
+    const [inquiries, total] = await Promise.all([
+      prisma.inquiry.findMany({
+        where,
+        skip,
+        take: limit,
+        orderBy: { [sortBy]: sortOrder },
+        include: {
+          artwork: {
+            select: {
+              id: true,
+              title: true,
+              slug: true,
+              images: { where: { type: 'MAIN' }, take: 1, orderBy: { displayOrder: 'asc' } },
+            },
+          },
+          user: { select: { id: true, email: true, name: true } },
+        },
+      }),
+      prisma.inquiry.count({ where }),
+    ]);
+
+    return {
+      data: inquiries,
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }
+
+  /**
+   * Respond to or update an inquiry (admin/staff).
+   * Validates status transitions: PENDING→RESPONDED, PENDING→CLOSED, RESPONDED→CLOSED.
+   */
+  async respond(inquiryId: string, staffUserId: string, data: RespondInquiryInput) {
+    const inquiry = await prisma.inquiry.findUnique({ where: { id: inquiryId } });
+    if (!inquiry) {
+      throw new Error('Inquiry not found');
+    }
+
+    // Determine target status
+    const targetStatus = data.status || (data.response ? 'RESPONDED' : inquiry.status);
+
+    // Validate transition
+    const allowed = VALID_TRANSITIONS[inquiry.status] || [];
+    if (targetStatus !== inquiry.status && !allowed.includes(targetStatus)) {
+      throw new Error(`Cannot transition from ${inquiry.status} to ${targetStatus}`);
+    }
+
+    const updateData: Prisma.InquiryUpdateInput = {};
+    if (data.response) {
+      updateData.response = data.response;
+      updateData.respondedAt = new Date();
+      updateData.respondedBy = staffUserId;
+    }
+    if (targetStatus !== inquiry.status) {
+      updateData.status = targetStatus;
+    }
+
+    const updated = await prisma.inquiry.update({
+      where: { id: inquiryId },
+      data: updateData,
+      include: {
+        artwork: { select: { id: true, title: true, slug: true } },
+        user: { select: { id: true, email: true, name: true } },
+      },
+    });
+
+    // Fire-and-forget email notification to customer when staff responds
+    if (data.response) {
+      void emailService
+        .sendInquiryResponseNotification({
+          inquiryId: updated.id,
+          customerName: inquiry.name,
+          customerEmail: inquiry.email,
+          customerPhone: inquiry.phone,
+          message: inquiry.message,
+          artworkTitle: updated.artwork.title,
+          artworkSlug: updated.artwork.slug,
+          response: data.response,
+        })
+        .catch((err) => console.error('Response notification failed:', err));
+    }
+
+    return updated;
+  }
+}
+
+export const inquiryService = new InquiryService();

--- a/apps/api/src/validators/inquiry.validator.ts
+++ b/apps/api/src/validators/inquiry.validator.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+export const createInquirySchema = z.object({
+  artworkId: z.string().cuid('Invalid artwork ID'),
+  name: z.string().min(1, 'Name is required').max(100),
+  email: z.string().email('Invalid email address'),
+  phone: z.string().optional(),
+  message: z.string().min(10, 'Message must be at least 10 characters').max(5000),
+});
+
+export const respondInquirySchema = z
+  .object({
+    response: z.string().min(1).max(5000).optional(),
+    status: z.enum(['RESPONDED', 'CLOSED']).optional(),
+  })
+  .refine((data) => data.response || data.status, {
+    message: 'At least one of response or status is required',
+  });
+
+export const listInquiriesQuerySchema = z.object({
+  page: z.coerce.number().int().positive().default(1),
+  limit: z.coerce.number().int().positive().max(100).default(20),
+  status: z.enum(['PENDING', 'RESPONDED', 'CLOSED']).optional(),
+  search: z.string().optional(),
+  sortBy: z.enum(['createdAt', 'updatedAt', 'status']).default('createdAt'),
+  sortOrder: z.enum(['asc', 'desc']).default('desc'),
+});
+
+export type CreateInquiryInput = z.infer<typeof createInquirySchema>;
+export type RespondInquiryInput = z.infer<typeof respondInquirySchema>;
+export type ListInquiriesQuery = z.infer<typeof listInquiriesQuerySchema>;

--- a/apps/web/app/admin/inquiries/page.tsx
+++ b/apps/web/app/admin/inquiries/page.tsx
@@ -1,0 +1,413 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useSession } from 'next-auth/react';
+import Link from 'next/link';
+import { Container, Section } from '@/components/layout';
+import { Button, Input, Textarea } from '@/components/ui';
+import { apiClient, type Inquiry } from '@/lib/api-client';
+import { Loader2, Mail, Phone, ChevronDown, ChevronUp, Send, XCircle, ShieldAlert } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+const STATUS_STYLES: Record<string, string> = {
+  PENDING: 'bg-warning-100 text-warning-800 border-warning-300',
+  RESPONDED: 'bg-info-100 text-info-800 border-info-300',
+  CLOSED: 'bg-success-100 text-success-800 border-success-300',
+};
+
+function StatusBadge({ status }: { status: string }) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border',
+        STATUS_STYLES[status] || 'bg-neutral-100 text-neutral-700 border-neutral-300'
+      )}
+    >
+      {status}
+    </span>
+  );
+}
+
+export default function AdminInquiriesPage() {
+  const { data: session } = useSession();
+  const [inquiries, setInquiries] = useState<Inquiry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = useState<string>('');
+  const [search, setSearch] = useState('');
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [responseText, setResponseText] = useState('');
+  const [responding, setResponding] = useState(false);
+  const [pagination, setPagination] = useState({
+    page: 1,
+    limit: 20,
+    total: 0,
+    totalPages: 0,
+  });
+
+  const isAuthorized =
+    session?.user?.role === 'ADMIN' || session?.user?.role === 'GALLERY_STAFF';
+
+  const fetchInquiries = async (page = 1) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      if (session?.accessToken) {
+        apiClient.setAccessToken(session.accessToken);
+      }
+
+      const params: Record<string, any> = { page, limit: 20 };
+      if (statusFilter) params.status = statusFilter;
+      if (search.trim()) params.search = search.trim();
+
+      const response = await apiClient.getAdminInquiries(params);
+      setInquiries(response.data);
+      if (response.pagination) {
+        setPagination(response.pagination);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load inquiries');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (session?.accessToken && isAuthorized) {
+      fetchInquiries(1);
+    } else if (session && !isAuthorized) {
+      setLoading(false);
+    }
+  }, [session?.accessToken, statusFilter]);
+
+  const handleSearch = () => {
+    fetchInquiries(1);
+  };
+
+  const handleRespond = async (inquiryId: string) => {
+    if (!responseText.trim()) return;
+    setResponding(true);
+
+    try {
+      if (session?.accessToken) {
+        apiClient.setAccessToken(session.accessToken);
+      }
+
+      await apiClient.respondToInquiry(inquiryId, {
+        response: responseText.trim(),
+        status: 'RESPONDED',
+      });
+
+      setResponseText('');
+      setExpandedId(null);
+      fetchInquiries(pagination.page);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to send response');
+    } finally {
+      setResponding(false);
+    }
+  };
+
+  const handleClose = async (inquiryId: string) => {
+    try {
+      if (session?.accessToken) {
+        apiClient.setAccessToken(session.accessToken);
+      }
+
+      await apiClient.respondToInquiry(inquiryId, { status: 'CLOSED' });
+      fetchInquiries(pagination.page);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to close inquiry');
+    }
+  };
+
+  // Access denied for non-admin/staff
+  if (session && !isAuthorized) {
+    return (
+      <Section spacing="lg" background="neutral">
+        <Container>
+          <div className="text-center py-20">
+            <ShieldAlert className="w-12 h-12 text-error-500 mx-auto mb-4" />
+            <h1 className="text-heading-2 font-serif text-neutral-900 mb-2">
+              Access Denied
+            </h1>
+            <p className="text-neutral-600 mb-6">
+              You don&apos;t have permission to view this page.
+            </p>
+            <Button asChild>
+              <Link href="/">Go Home</Link>
+            </Button>
+          </div>
+        </Container>
+      </Section>
+    );
+  }
+
+  return (
+    <Section spacing="lg" background="neutral">
+      <Container size="xl">
+        {/* Header */}
+        <div className="mb-8">
+          <h1 className="text-display font-serif text-neutral-900 mb-2">
+            Inquiry Management
+          </h1>
+          <p className="text-body-lg text-neutral-600">
+            View and respond to customer inquiries
+          </p>
+        </div>
+
+        {/* Filters */}
+        <div className="flex flex-col sm:flex-row gap-3 mb-6">
+          <div className="flex gap-2">
+            {['', 'PENDING', 'RESPONDED', 'CLOSED'].map((value) => (
+              <Button
+                key={value}
+                variant={statusFilter === value ? 'primary' : 'outline'}
+                size="sm"
+                onClick={() => setStatusFilter(value)}
+              >
+                {value || 'All'}
+              </Button>
+            ))}
+          </div>
+          <div className="flex gap-2 flex-1">
+            <Input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search by name or email..."
+              className="flex-1"
+              onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
+            />
+            <Button variant="outline" size="md" onClick={handleSearch}>
+              Search
+            </Button>
+          </div>
+        </div>
+
+        {/* Summary */}
+        {!loading && inquiries.length > 0 && (
+          <p className="text-sm text-neutral-600 mb-4">
+            {pagination.total} {pagination.total === 1 ? 'inquiry' : 'inquiries'} found
+          </p>
+        )}
+
+        {/* Error */}
+        {error && (
+          <div className="bg-error-50 border border-error-200 rounded-lg p-4 text-error-700 mb-6">
+            {error}
+          </div>
+        )}
+
+        {/* Loading */}
+        {loading && (
+          <div className="flex items-center justify-center py-20">
+            <Loader2 className="w-8 h-8 text-primary-600 animate-spin" />
+          </div>
+        )}
+
+        {/* Content */}
+        {!loading && !error && (
+          <>
+            {inquiries.length === 0 ? (
+              <div className="text-center py-20">
+                <Mail className="w-12 h-12 text-neutral-400 mx-auto mb-4" />
+                <h2 className="text-heading-3 font-serif text-neutral-900 mb-2">
+                  No inquiries found
+                </h2>
+                <p className="text-neutral-600">
+                  {statusFilter
+                    ? `No ${statusFilter.toLowerCase()} inquiries.`
+                    : 'No inquiries have been submitted yet.'}
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {inquiries.map((inquiry) => {
+                  const isExpanded = expandedId === inquiry.id;
+
+                  return (
+                    <div
+                      key={inquiry.id}
+                      className="bg-white rounded-lg border border-neutral-200 overflow-hidden"
+                    >
+                      {/* Summary Row */}
+                      <button
+                        onClick={() => {
+                          setExpandedId(isExpanded ? null : inquiry.id);
+                          setResponseText('');
+                        }}
+                        className="w-full flex items-center gap-4 p-4 text-left hover:bg-neutral-50 transition-colors"
+                      >
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-3 mb-1">
+                            <span className="font-medium text-neutral-900 truncate">
+                              {inquiry.name}
+                            </span>
+                            <StatusBadge status={inquiry.status} />
+                          </div>
+                          <p className="text-sm text-neutral-500 truncate">
+                            {inquiry.artwork?.title ?? 'Unknown artwork'} &middot;{' '}
+                            {new Date(inquiry.createdAt).toLocaleDateString('en-US', {
+                              month: 'short',
+                              day: 'numeric',
+                              year: 'numeric',
+                            })}
+                          </p>
+                        </div>
+                        {isExpanded ? (
+                          <ChevronUp className="w-5 h-5 text-neutral-400 shrink-0" />
+                        ) : (
+                          <ChevronDown className="w-5 h-5 text-neutral-400 shrink-0" />
+                        )}
+                      </button>
+
+                      {/* Expanded Detail */}
+                      {isExpanded && (
+                        <div className="border-t border-neutral-200 p-4 space-y-4">
+                          {/* Contact Info */}
+                          <div className="flex flex-wrap gap-4 text-sm">
+                            <a
+                              href={`mailto:${inquiry.email}`}
+                              className="inline-flex items-center gap-1.5 text-primary-600 hover:underline"
+                            >
+                              <Mail className="w-4 h-4" />
+                              {inquiry.email}
+                            </a>
+                            {inquiry.phone && (
+                              <a
+                                href={`tel:${inquiry.phone}`}
+                                className="inline-flex items-center gap-1.5 text-primary-600 hover:underline"
+                              >
+                                <Phone className="w-4 h-4" />
+                                {inquiry.phone}
+                              </a>
+                            )}
+                          </div>
+
+                          {/* Artwork Link */}
+                          {inquiry.artwork && (
+                            <div className="text-sm">
+                              <span className="text-neutral-500">Artwork: </span>
+                              <Link
+                                href={`/artworks/${inquiry.artwork.slug}`}
+                                className="text-primary-600 hover:underline"
+                              >
+                                {inquiry.artwork.title}
+                              </Link>
+                            </div>
+                          )}
+
+                          {/* Message */}
+                          <div>
+                            <p className="text-xs uppercase tracking-wider text-neutral-500 mb-1">
+                              Message
+                            </p>
+                            <p className="text-body text-neutral-700 whitespace-pre-line bg-neutral-50 rounded-lg p-3">
+                              {inquiry.message}
+                            </p>
+                          </div>
+
+                          {/* Existing Response */}
+                          {inquiry.response && (
+                            <div>
+                              <p className="text-xs uppercase tracking-wider text-neutral-500 mb-1">
+                                Staff Response
+                              </p>
+                              <p className="text-body text-neutral-700 whitespace-pre-line bg-info-50 rounded-lg p-3 border border-info-200">
+                                {inquiry.response}
+                              </p>
+                              {inquiry.respondedAt && (
+                                <p className="text-xs text-neutral-400 mt-1">
+                                  Responded on{' '}
+                                  {new Date(inquiry.respondedAt).toLocaleDateString('en-US', {
+                                    month: 'short',
+                                    day: 'numeric',
+                                    year: 'numeric',
+                                  })}
+                                </p>
+                              )}
+                            </div>
+                          )}
+
+                          {/* Actions */}
+                          {inquiry.status !== 'CLOSED' && (
+                            <div className="space-y-3 pt-2 border-t border-neutral-100">
+                              {inquiry.status === 'PENDING' && (
+                                <div className="space-y-2">
+                                  <Textarea
+                                    value={responseText}
+                                    onChange={(e) => setResponseText(e.target.value)}
+                                    placeholder="Write your response..."
+                                    rows={3}
+                                  />
+                                  <div className="flex gap-2">
+                                    <Button
+                                      size="sm"
+                                      onClick={() => handleRespond(inquiry.id)}
+                                      loading={responding}
+                                      disabled={!responseText.trim()}
+                                    >
+                                      <Send className="w-4 h-4" />
+                                      Send Response
+                                    </Button>
+                                    <Button
+                                      size="sm"
+                                      variant="outline"
+                                      onClick={() => handleClose(inquiry.id)}
+                                    >
+                                      <XCircle className="w-4 h-4" />
+                                      Close
+                                    </Button>
+                                  </div>
+                                </div>
+                              )}
+
+                              {inquiry.status === 'RESPONDED' && (
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={() => handleClose(inquiry.id)}
+                                >
+                                  <XCircle className="w-4 h-4" />
+                                  Close Inquiry
+                                </Button>
+                              )}
+                            </div>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+
+            {/* Pagination */}
+            {pagination.totalPages > 1 && (
+              <div className="flex items-center justify-center gap-2 pt-8">
+                <Button
+                  variant="outline"
+                  onClick={() => fetchInquiries(pagination.page - 1)}
+                  disabled={pagination.page === 1}
+                >
+                  Previous
+                </Button>
+                <span className="px-4 text-sm text-neutral-600">
+                  Page {pagination.page} of {pagination.totalPages}
+                </span>
+                <Button
+                  variant="outline"
+                  onClick={() => fetchInquiries(pagination.page + 1)}
+                  disabled={pagination.page === pagination.totalPages}
+                >
+                  Next
+                </Button>
+              </div>
+            )}
+          </>
+        )}
+      </Container>
+    </Section>
+  );
+}

--- a/apps/web/app/artworks/[slug]/page.tsx
+++ b/apps/web/app/artworks/[slug]/page.tsx
@@ -6,7 +6,7 @@ import { useSession } from 'next-auth/react';
 import Link from 'next/link';
 import { Container, Section } from '@/components/layout';
 import { ImageZoom } from '@/components/ui';
-import { ArtworkCard } from '@/components/artwork';
+import { ArtworkCard, InquiryForm } from '@/components/artwork';
 import { Button } from '@/components/ui';
 import { apiClient, type Artwork } from '@/lib/api-client';
 import { useFavorite } from '@/hooks/use-favorite';
@@ -24,6 +24,7 @@ export default function ArtworkDetailPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedImageIndex, setSelectedImageIndex] = useState(0);
+  const [showInquiryForm, setShowInquiryForm] = useState(false);
 
   // Fetch artwork details — set access token so API returns isFavorited
   useEffect(() => {
@@ -249,8 +250,13 @@ export default function ArtworkDetailPage() {
               <div className="flex gap-3">
                 {isAvailable ? (
                   <>
-                    <Button size="lg" className="flex-1">
-                      Inquire
+                    <Button
+                      size="lg"
+                      className="flex-1"
+                      variant={showInquiryForm ? 'outline' : 'primary'}
+                      onClick={() => setShowInquiryForm(!showInquiryForm)}
+                    >
+                      {showInquiryForm ? 'Close' : 'Inquire'}
                     </Button>
                     <FavoriteButton
                       artworkId={artwork.id}
@@ -267,6 +273,11 @@ export default function ArtworkDetailPage() {
                   <Share2 className="w-5 h-5" />
                 </Button>
               </div>
+
+              {/* Inquiry Form */}
+              {showInquiryForm && isAvailable && (
+                <InquiryForm artworkId={artwork.id} />
+              )}
 
               {/* Description */}
               {artwork.description && (

--- a/apps/web/components/artwork/index.ts
+++ b/apps/web/components/artwork/index.ts
@@ -4,3 +4,4 @@
  */
 
 export { ArtworkCard } from './artwork-card';
+export { InquiryForm } from './inquiry-form';

--- a/apps/web/components/artwork/inquiry-form.tsx
+++ b/apps/web/components/artwork/inquiry-form.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { useState } from 'react';
+import { useSession } from 'next-auth/react';
+import { Button, Input, Textarea, Label } from '@/components/ui';
+import { apiClient } from '@/lib/api-client';
+import { CheckCircle2 } from 'lucide-react';
+
+interface InquiryFormProps {
+  artworkId: string;
+}
+
+export function InquiryForm({ artworkId }: InquiryFormProps) {
+  const { data: session } = useSession();
+
+  const [name, setName] = useState(session?.user?.name ?? '');
+  const [email, setEmail] = useState(session?.user?.email ?? '');
+  const [phone, setPhone] = useState('');
+  const [message, setMessage] = useState('');
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  const validate = () => {
+    const newErrors: Record<string, string> = {};
+
+    if (!name.trim()) newErrors.name = 'Name is required';
+    if (!email.trim()) {
+      newErrors.email = 'Email is required';
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      newErrors.email = 'Invalid email address';
+    }
+    if (!message.trim()) {
+      newErrors.message = 'Message is required';
+    } else if (message.trim().length < 10) {
+      newErrors.message = 'Message must be at least 10 characters';
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!validate()) return;
+
+    setLoading(true);
+
+    try {
+      if (session?.accessToken) {
+        apiClient.setAccessToken(session.accessToken);
+      }
+
+      await apiClient.createInquiry({
+        artworkId,
+        name: name.trim(),
+        email: email.trim(),
+        phone: phone.trim() || undefined,
+        message: message.trim(),
+      });
+
+      setSubmitted(true);
+    } catch (err) {
+      setErrors({
+        form: err instanceof Error ? err.message : 'Failed to send inquiry. Please try again.',
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (submitted) {
+    return (
+      <div className="rounded-lg border-2 border-success-200 bg-success-50 p-6 text-center">
+        <CheckCircle2 className="w-10 h-10 text-success-600 mx-auto mb-3" />
+        <h3 className="text-heading-4 font-serif text-neutral-900 mb-2">
+          Inquiry Sent
+        </h3>
+        <p className="text-body text-neutral-600">
+          Thank you for your interest. Our gallery team will respond to your inquiry shortly.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 rounded-lg border-2 border-neutral-200 p-6">
+      <h3 className="text-heading-4 font-serif text-neutral-900 mb-1">
+        Inquire About This Artwork
+      </h3>
+      <p className="text-body-sm text-neutral-500 mb-4">
+        Fill in your details and our team will get back to you.
+      </p>
+
+      {errors.form && (
+        <div className="bg-error-50 border border-error-200 rounded-lg p-3 text-sm text-error-700">
+          {errors.form}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="inquiry-name" required>Name</Label>
+          <Input
+            id="inquiry-name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Your name"
+            error={!!errors.name}
+          />
+          {errors.name && <p className="text-xs text-error-600">{errors.name}</p>}
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="inquiry-email" required>Email</Label>
+          <Input
+            id="inquiry-email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="you@example.com"
+            error={!!errors.email}
+          />
+          {errors.email && <p className="text-xs text-error-600">{errors.email}</p>}
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="inquiry-phone">Phone (optional)</Label>
+        <Input
+          id="inquiry-phone"
+          type="tel"
+          value={phone}
+          onChange={(e) => setPhone(e.target.value)}
+          placeholder="+1 (555) 000-0000"
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="inquiry-message" required>Message</Label>
+        <Textarea
+          id="inquiry-message"
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          placeholder="I'm interested in this artwork and would like to know more about..."
+          rows={4}
+          error={!!errors.message}
+        />
+        {errors.message && <p className="text-xs text-error-600">{errors.message}</p>}
+      </div>
+
+      <Button type="submit" loading={loading} className="w-full">
+        Send Inquiry
+      </Button>
+    </form>
+  );
+}

--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -149,6 +149,46 @@ export interface ToggleFavoriteResult {
   id?: string;
 }
 
+export interface CreateInquiryInput {
+  artworkId: string;
+  name: string;
+  email: string;
+  phone?: string;
+  message: string;
+}
+
+export interface Inquiry {
+  id: string;
+  userId: string | null;
+  artworkId: string;
+  name: string;
+  email: string;
+  phone: string | null;
+  message: string;
+  status: 'PENDING' | 'RESPONDED' | 'CLOSED';
+  response: string | null;
+  respondedAt: string | null;
+  respondedBy: string | null;
+  createdAt: string;
+  updatedAt: string;
+  artwork?: {
+    id: string;
+    title: string;
+    slug: string;
+    images?: ArtworkImage[];
+  };
+  user?: {
+    id: string;
+    email: string;
+    name: string | null;
+  } | null;
+}
+
+export interface RespondInquiryInput {
+  response?: string;
+  status?: 'RESPONDED' | 'CLOSED';
+}
+
 class ApiClient {
   private baseUrl: string;
   private accessToken: string | null = null;
@@ -320,6 +360,51 @@ class ApiClient {
    */
   async removeFavorite(favoriteId: string): Promise<void> {
     await this.fetch(`/favorites/${favoriteId}`, { method: 'DELETE' });
+  }
+
+  // ── Inquiries ──────────────────────────────────────────────────────────
+
+  /**
+   * Submit an inquiry on an artwork (works for guests and authenticated users)
+   */
+  async createInquiry(data: CreateInquiryInput): Promise<ApiResponse<Inquiry>> {
+    return this.fetch<Inquiry>('/inquiries', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  /**
+   * List the authenticated user's inquiries
+   */
+  async getUserInquiries(
+    params: PaginationParams & { status?: string } = {}
+  ): Promise<ApiResponse<Inquiry[]>> {
+    const queryString = this.buildQueryString(params);
+    return this.fetch<Inquiry[]>(`/inquiries${queryString}`);
+  }
+
+  /**
+   * List all inquiries (admin/staff only)
+   */
+  async getAdminInquiries(
+    params: PaginationParams & { status?: string; search?: string } = {}
+  ): Promise<ApiResponse<Inquiry[]>> {
+    const queryString = this.buildQueryString(params);
+    return this.fetch<Inquiry[]>(`/inquiries/admin${queryString}`);
+  }
+
+  /**
+   * Respond to or update an inquiry (admin/staff only)
+   */
+  async respondToInquiry(
+    id: string,
+    data: RespondInquiryInput
+  ): Promise<ApiResponse<Inquiry>> {
+    return this.fetch<Inquiry>(`/inquiries/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    });
   }
 }
 

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,5 +1,5 @@
 export { auth as middleware } from '@/lib/auth';
 
 export const config = {
-  matcher: ['/account/:path*', '/favorites/:path*'],
+  matcher: ['/account/:path*', '/favorites/:path*', '/admin/:path*'],
 };

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "clean": "turbo run clean && rm -rf node_modules"
   },
   "devDependencies": {
-    "turbo": "^2.0.0",
+    "eslint": "^8.57.0",
     "prettier": "^3.2.0",
-    "eslint": "^8.57.0"
+    "turbo": "^2.0.0"
   },
   "engines": {
     "node": ">=18.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@prisma/client':
         specifier: ^6.3.0
         version: 6.19.2(prisma@6.19.2)(typescript@5.9.3)
+      '@sendgrid/mail':
+        specifier: ^8.1.4
+        version: 8.1.6
       bcryptjs:
         specifier: ^3.0.3
         version: 3.0.3
@@ -1655,7 +1658,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -1796,7 +1799,7 @@ packages:
     deprecated: Use @eslint/config-array instead
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -4166,6 +4169,33 @@ packages:
       string-argv: 0.3.2
     transitivePeerDependencies:
       - '@types/node'
+    dev: false
+
+  /@sendgrid/client@8.1.6:
+    resolution: {integrity: sha512-/BHu0hqwXNHr2aLhcXU7RmmlVqrdfrbY9KpaNj00KZHlVOVoRxRVrpOCabIB+91ISXJ6+mLM9vpaVUhK6TwBWA==}
+    engines: {node: '>=12.*'}
+    dependencies:
+      '@sendgrid/helpers': 8.0.0
+      axios: 1.12.2(debug@4.3.4)
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
+  /@sendgrid/helpers@8.0.0:
+    resolution: {integrity: sha512-Ze7WuW2Xzy5GT5WRx+yEv89fsg/pgy3T1E3FS0QEx0/VvRmigMZ5qyVGhJz4SxomegDkzXv/i0aFPpHKN8qdAA==}
+    engines: {node: '>= 12.0.0'}
+    dependencies:
+      deepmerge: 4.3.1
+    dev: false
+
+  /@sendgrid/mail@8.1.6:
+    resolution: {integrity: sha512-/ZqxUvKeEztU9drOoPC/8opEPOk+jLlB2q4+xpx6HVLq6aFu3pMpalkTpAQz8XfRfpLp8O25bh6pGPcHDCYpqg==}
+    engines: {node: '>=12.*'}
+    dependencies:
+      '@sendgrid/client': 8.1.6
+      '@sendgrid/helpers': 8.0.0
+    transitivePeerDependencies:
+      - debug
     dev: false
 
   /@simov/deep-extend@1.0.0:
@@ -8067,6 +8097,18 @@ packages:
       ms: 2.1.2
     dev: false
 
+  /debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
+    dev: true
+
   /debug@4.4.3(supports-color@5.5.0):
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -8990,7 +9032,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2


### PR DESCRIPTION
## Summary
- **#38** — Inquiry API endpoints: `POST /inquiries` (guest + auth), `GET /inquiries` (user), `GET /inquiries/admin` (staff), `PATCH /inquiries/:id` (respond/close) with Zod validation, status transition guards, and optional `userId` schema migration
- **#39** — Inquiry form on artwork detail page: collapsible form with client-side validation, session pre-fill, and success confirmation
- **#40** — Admin inquiry management dashboard: filterable/searchable table with expandable cards, inline response textarea, status updates, role-based access control, and pagination
- **#41** — SendGrid email notifications: feature-gated fire-and-forget emails to staff on new inquiries and to customers on staff responses

## Test plan
- [ ] `POST /inquiries` works as guest (no auth header) and authenticated
- [ ] `GET /inquiries` returns only the authenticated user's inquiries
- [ ] `GET /inquiries/admin` rejects non-admin/staff, returns all inquiries with status filter and search
- [ ] `PATCH /inquiries/:id` validates status transitions (PENDING→RESPONDED, PENDING→CLOSED, RESPONDED→CLOSED, no backwards)
- [ ] Inquiry form renders on artwork detail page when "Inquire" is clicked
- [ ] Form pre-fills name/email from session when logged in
- [ ] Form validates required fields and minimum message length
- [ ] Admin dashboard renders at `/admin/inquiries`, shows access denied for non-staff
- [ ] Admin can filter by status, search by name/email, and paginate
- [ ] Admin can send response and close inquiries inline
- [ ] Email notifications are skipped when `SENDGRID_API_KEY` is not set (no errors in dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)