### PR TITLE
feat: CMS integration (Sprint 9, #42–#44)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,7 +17,7 @@
     "lint": "eslint src --ext .ts"
   },
   "dependencies": {
-    "@prisma/client": "^6.3.0",
+    "@prisma/client": "^6.19.2",
     "@sendgrid/mail": "^8.1.4",
     "bcryptjs": "^3.0.3",
     "cloudinary": "^2.9.0",

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -58,6 +58,7 @@ enum UserRole {
 
 model Artist {
   id          String  @id @default(cuid())
+  strapiId    Int?    @unique
   name        String
   slug        String  @unique
   bio         String? @db.Text
@@ -90,6 +91,7 @@ model Artist {
 
 model Artwork {
   id          String  @id @default(cuid())
+  strapiId    Int?    @unique
   title       String
   slug        String  @unique
   description String? @db.Text
@@ -227,6 +229,7 @@ enum ImageType {
 
 model Collection {
   id          String  @id @default(cuid())
+  strapiId    Int?    @unique
   title       String
   slug        String  @unique
   description String? @db.Text
@@ -319,4 +322,37 @@ model Favorite {
   @@index([userId])
   @@index([artworkId])
   @@map("favorites")
+}
+
+// ============================================================================
+// EDITORIAL CONTENT
+// ============================================================================
+
+model Article {
+  id            String           @id @default(cuid())
+  strapiId      Int?             @unique
+  title         String
+  slug          String           @unique
+  content       String           @db.Text
+  excerpt       String?          @db.Text
+  coverImageUrl String?
+  author        String?
+  category      ArticleCategory?
+  publishedDate DateTime?
+  featured      Boolean          @default(false)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([category])
+  @@index([featured])
+  @@map("articles")
+}
+
+enum ArticleCategory {
+  ARTIST_SPOTLIGHT
+  EXHIBITION
+  BEHIND_THE_SCENES
+  NEWS
+  GUIDE
 }

--- a/apps/api/src/config/environment.ts
+++ b/apps/api/src/config/environment.ts
@@ -35,6 +35,12 @@ export const config = {
     fromEmail: process.env.FROM_EMAIL || 'noreply@artspot.com',
     staffEmail: process.env.STAFF_EMAIL || '',
   },
+
+  // CMS (Strapi)
+  cms: {
+    webhookSecret: process.env.CMS_WEBHOOK_SECRET || '',
+    strapiUrl: process.env.STRAPI_URL || 'http://localhost:1337',
+  },
 } as const;
 
 // Validate required environment variables in production

--- a/apps/api/src/controllers/article.controller.ts
+++ b/apps/api/src/controllers/article.controller.ts
@@ -1,0 +1,67 @@
+import { Request, Response, NextFunction } from 'express';
+import { articleService } from '../services/article.service';
+import { listArticlesQuerySchema } from '../validators/article.validator';
+import { AppError } from '../middleware/error-handler';
+
+export class ArticleController {
+  /**
+   * GET /articles
+   * List articles with pagination, category filter, search
+   */
+  async list(req: Request, res: Response, next: NextFunction) {
+    try {
+      const query = listArticlesQuerySchema.parse(req.query);
+      const result = await articleService.list(query);
+
+      res.json({
+        success: true,
+        ...result,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /articles/featured
+   * Get featured articles
+   */
+  async featured(req: Request, res: Response, next: NextFunction) {
+    try {
+      const limitParam = typeof req.query.limit === 'string' ? req.query.limit : '6';
+      const limit = parseInt(limitParam, 10);
+      const articles = await articleService.getFeatured(limit);
+
+      res.json({
+        success: true,
+        data: articles,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /articles/:slug
+   * Get single article by slug
+   */
+  async getBySlug(req: Request, res: Response, next: NextFunction) {
+    try {
+      const slug = req.params.slug as string;
+      const article = await articleService.getBySlug(slug);
+
+      if (!article) {
+        return next(new AppError('Article not found', 404));
+      }
+
+      res.json({
+        success: true,
+        data: article,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+}
+
+export const articleController = new ArticleController();

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -20,6 +20,8 @@ import collectionsRouter from './routes/collections';
 import authRouter from './routes/auth';
 import favoritesRouter from './routes/favorites';
 import inquiriesRouter from './routes/inquiries';
+import webhooksRouter from './routes/webhooks';
+import articlesRouter from './routes/articles';
 import { initializeCloudinary } from './config/cloudinary';
 
 // Initialize Cloudinary AFTER env vars are loaded
@@ -58,6 +60,8 @@ app.use('/artists', artistsRouter);
 app.use('/collections', collectionsRouter);
 app.use('/favorites', favoritesRouter);
 app.use('/inquiries', inquiriesRouter);
+app.use('/webhooks', webhooksRouter);
+app.use('/articles', articlesRouter);
 
 // 404 handler
 app.use('*', (req, res) => {

--- a/apps/api/src/routes/articles.ts
+++ b/apps/api/src/routes/articles.ts
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+import { articleController } from '../controllers/article.controller';
+
+const router = Router();
+
+// List articles with pagination, category filter, search
+// GET /articles?page=1&limit=20&category=NEWS&search=modern
+router.get('/', articleController.list.bind(articleController));
+
+// Get featured articles
+// GET /articles/featured?limit=6
+router.get('/featured', articleController.featured.bind(articleController));
+
+// Get single article by slug
+// GET /articles/:slug
+router.get('/:slug', articleController.getBySlug.bind(articleController));
+
+export default router;

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -1,0 +1,37 @@
+import { Router, Request, Response } from 'express';
+import { config } from '../config/environment';
+import { cmsSyncService } from '../services/cms-sync.service';
+
+const router = Router();
+
+/**
+ * POST /webhooks/cms
+ * Receives Strapi lifecycle events and syncs data into the API database.
+ * Validated via shared secret header — no JWT auth middleware.
+ */
+router.post('/cms', (req: Request, res: Response) => {
+  // Validate webhook secret
+  const secret = req.headers['x-webhook-secret'] as string | undefined;
+
+  if (!config.cms.webhookSecret || secret !== config.cms.webhookSecret) {
+    res.status(401).json({ success: false, message: 'Unauthorized' });
+    return;
+  }
+
+  const { event, model, entry } = req.body;
+
+  if (!event || !model || !entry) {
+    res.status(400).json({ success: false, message: 'Invalid webhook payload' });
+    return;
+  }
+
+  // Respond immediately — sync runs fire-and-forget
+  res.status(200).json({ success: true, message: 'Webhook received' });
+
+  // Process in background
+  cmsSyncService.handleEvent(event, model, entry).catch((err) => {
+    console.error(`CMS sync error [${event} ${model}]:`, err);
+  });
+});
+
+export default router;

--- a/apps/api/src/services/article.service.ts
+++ b/apps/api/src/services/article.service.ts
@@ -1,0 +1,54 @@
+import { Prisma } from '@prisma/client';
+import { prisma } from '../config/database';
+import type { ListArticlesQuery } from '../validators/article.validator';
+
+export class ArticleService {
+  async list(query: ListArticlesQuery) {
+    const { page, limit, category, search, featured, sortBy, sortOrder } = query;
+    const skip = (page - 1) * limit;
+
+    const where: Prisma.ArticleWhereInput = {};
+    if (category) where.category = category;
+    if (featured !== undefined) where.featured = featured;
+    if (search) {
+      where.OR = [
+        { title: { contains: search, mode: 'insensitive' } },
+        { excerpt: { contains: search, mode: 'insensitive' } },
+      ];
+    }
+
+    const [articles, total] = await Promise.all([
+      prisma.article.findMany({
+        where,
+        skip,
+        take: limit,
+        orderBy: { [sortBy]: sortOrder },
+      }),
+      prisma.article.count({ where }),
+    ]);
+
+    return {
+      data: articles,
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }
+
+  async getFeatured(limit = 6) {
+    return prisma.article.findMany({
+      where: { featured: true },
+      orderBy: { publishedDate: 'desc' },
+      take: limit,
+    });
+  }
+
+  async getBySlug(slug: string) {
+    return prisma.article.findUnique({ where: { slug } });
+  }
+}
+
+export const articleService = new ArticleService();

--- a/apps/api/src/services/cms-sync.service.ts
+++ b/apps/api/src/services/cms-sync.service.ts
@@ -1,0 +1,269 @@
+import { prisma } from '../config/database';
+
+type StrapiEvent = 'entry.create' | 'entry.update' | 'entry.delete';
+
+export class CmsSyncService {
+  async handleEvent(event: StrapiEvent, model: string, entry: any) {
+    switch (model) {
+      case 'artist':
+        return this.syncArtist(event, entry);
+      case 'artwork':
+        return this.syncArtwork(event, entry);
+      case 'collection':
+        return this.syncCollection(event, entry);
+      case 'article':
+        return this.syncArticle(event, entry);
+      default:
+        console.log(`CMS sync: unhandled model "${model}"`);
+    }
+  }
+
+  private async syncArtist(event: StrapiEvent, entry: any) {
+    const strapiId = entry.id;
+
+    if (event === 'entry.delete') {
+      await prisma.artist.deleteMany({ where: { strapiId } });
+      return;
+    }
+
+    await prisma.artist.upsert({
+      where: { strapiId },
+      create: {
+        strapiId,
+        name: entry.name,
+        slug: entry.slug,
+        bio: entry.bio || null,
+        statement: entry.statement || null,
+        location: entry.location || null,
+        website: entry.website || null,
+        email: entry.email || null,
+        phoneNumber: entry.phoneNumber || null,
+        profileImageUrl: this.extractMediaUrl(entry.profileImage),
+        featured: entry.featured ?? false,
+        verified: entry.verified ?? false,
+      },
+      update: {
+        name: entry.name,
+        slug: entry.slug,
+        bio: entry.bio || null,
+        statement: entry.statement || null,
+        location: entry.location || null,
+        website: entry.website || null,
+        email: entry.email || null,
+        phoneNumber: entry.phoneNumber || null,
+        profileImageUrl: this.extractMediaUrl(entry.profileImage),
+        featured: entry.featured ?? false,
+        verified: entry.verified ?? false,
+      },
+    });
+  }
+
+  private async syncArtwork(event: StrapiEvent, entry: any) {
+    const strapiId = entry.id;
+
+    if (event === 'entry.delete') {
+      await prisma.artwork.deleteMany({ where: { strapiId } });
+      return;
+    }
+
+    // Resolve artist relation via strapiId
+    let artistId: string | undefined;
+    if (entry.artist?.id) {
+      const artist = await prisma.artist.findUnique({
+        where: { strapiId: entry.artist.id },
+        select: { id: true },
+      });
+      artistId = artist?.id;
+    }
+
+    if (!artistId) {
+      console.error(`CMS sync: artwork "${entry.title}" has no valid artist, skipping`);
+      return;
+    }
+
+    const artwork = await prisma.artwork.upsert({
+      where: { strapiId },
+      create: {
+        strapiId,
+        title: entry.title,
+        slug: entry.slug,
+        description: entry.description || null,
+        artistId,
+        medium: entry.medium || 'OTHER',
+        style: entry.style || null,
+        year: entry.year || null,
+        width: entry.width || null,
+        height: entry.height || null,
+        depth: entry.depth || null,
+        price: entry.price,
+        currency: entry.currency || 'USD',
+        status: entry.status || 'AVAILABLE',
+        featured: entry.featured ?? false,
+        edition: entry.edition || null,
+        materials: entry.materials || null,
+        signature: entry.signature || null,
+        certificate: entry.certificate ?? false,
+        framed: entry.framed ?? false,
+      },
+      update: {
+        title: entry.title,
+        slug: entry.slug,
+        description: entry.description || null,
+        artistId,
+        medium: entry.medium || 'OTHER',
+        style: entry.style || null,
+        year: entry.year || null,
+        width: entry.width || null,
+        height: entry.height || null,
+        depth: entry.depth || null,
+        price: entry.price,
+        currency: entry.currency || 'USD',
+        status: entry.status || 'AVAILABLE',
+        featured: entry.featured ?? false,
+        edition: entry.edition || null,
+        materials: entry.materials || null,
+        signature: entry.signature || null,
+        certificate: entry.certificate ?? false,
+        framed: entry.framed ?? false,
+      },
+    });
+
+    // Sync images — replace all existing images with CMS images
+    if (entry.images && Array.isArray(entry.images)) {
+      await prisma.artworkImage.deleteMany({ where: { artworkId: artwork.id } });
+
+      for (let i = 0; i < entry.images.length; i++) {
+        const img = entry.images[i];
+        const url = img.url || '';
+        await prisma.artworkImage.create({
+          data: {
+            artworkId: artwork.id,
+            publicId: img.hash || `strapi-${strapiId}-${i}`,
+            url,
+            secureUrl: url.replace('http://', 'https://'),
+            width: img.width || 0,
+            height: img.height || 0,
+            format: img.ext?.replace('.', '') || img.mime?.split('/')[1] || 'jpg',
+            size: img.size ? Math.round(img.size * 1024) : 0,
+            type: i === 0 ? 'MAIN' : 'ALTERNATE',
+            displayOrder: i,
+          },
+        });
+      }
+    }
+
+    // Sync collection relations
+    if (entry.collections && Array.isArray(entry.collections)) {
+      // Remove existing collection links
+      await prisma.collectionArtwork.deleteMany({ where: { artworkId: artwork.id } });
+
+      for (const col of entry.collections) {
+        const collection = await prisma.collection.findUnique({
+          where: { strapiId: col.id },
+          select: { id: true },
+        });
+        if (collection) {
+          await prisma.collectionArtwork.create({
+            data: {
+              collectionId: collection.id,
+              artworkId: artwork.id,
+            },
+          });
+        }
+      }
+    }
+  }
+
+  private async syncCollection(event: StrapiEvent, entry: any) {
+    const strapiId = entry.id;
+
+    if (event === 'entry.delete') {
+      await prisma.collection.deleteMany({ where: { strapiId } });
+      return;
+    }
+
+    const collection = await prisma.collection.upsert({
+      where: { strapiId },
+      create: {
+        strapiId,
+        title: entry.title,
+        slug: entry.slug,
+        description: entry.description || null,
+        coverImageUrl: this.extractMediaUrl(entry.coverImage),
+        featured: entry.featured ?? false,
+      },
+      update: {
+        title: entry.title,
+        slug: entry.slug,
+        description: entry.description || null,
+        coverImageUrl: this.extractMediaUrl(entry.coverImage),
+        featured: entry.featured ?? false,
+      },
+    });
+
+    // Sync artwork relations
+    if (entry.artworks && Array.isArray(entry.artworks)) {
+      await prisma.collectionArtwork.deleteMany({ where: { collectionId: collection.id } });
+
+      for (let i = 0; i < entry.artworks.length; i++) {
+        const aw = entry.artworks[i];
+        const artwork = await prisma.artwork.findUnique({
+          where: { strapiId: aw.id },
+          select: { id: true },
+        });
+        if (artwork) {
+          await prisma.collectionArtwork.create({
+            data: {
+              collectionId: collection.id,
+              artworkId: artwork.id,
+              displayOrder: i,
+            },
+          });
+        }
+      }
+    }
+  }
+
+  private async syncArticle(event: StrapiEvent, entry: any) {
+    const strapiId = entry.id;
+
+    if (event === 'entry.delete') {
+      await prisma.article.deleteMany({ where: { strapiId } });
+      return;
+    }
+
+    await prisma.article.upsert({
+      where: { strapiId },
+      create: {
+        strapiId,
+        title: entry.title,
+        slug: entry.slug,
+        content: entry.content || '',
+        excerpt: entry.excerpt || null,
+        coverImageUrl: this.extractMediaUrl(entry.coverImage),
+        author: entry.author || null,
+        category: entry.category || null,
+        publishedDate: entry.publishedDate ? new Date(entry.publishedDate) : null,
+        featured: entry.featured ?? false,
+      },
+      update: {
+        title: entry.title,
+        slug: entry.slug,
+        content: entry.content || '',
+        excerpt: entry.excerpt || null,
+        coverImageUrl: this.extractMediaUrl(entry.coverImage),
+        author: entry.author || null,
+        category: entry.category || null,
+        publishedDate: entry.publishedDate ? new Date(entry.publishedDate) : null,
+        featured: entry.featured ?? false,
+      },
+    });
+  }
+
+  private extractMediaUrl(media: any): string | null {
+    if (!media) return null;
+    return media.url || null;
+  }
+}
+
+export const cmsSyncService = new CmsSyncService();

--- a/apps/api/src/validators/article.validator.ts
+++ b/apps/api/src/validators/article.validator.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+export const listArticlesQuerySchema = z.object({
+  page: z.coerce.number().int().positive().default(1),
+  limit: z.coerce.number().int().positive().max(100).default(20),
+  category: z
+    .enum(['ARTIST_SPOTLIGHT', 'EXHIBITION', 'BEHIND_THE_SCENES', 'NEWS', 'GUIDE'])
+    .optional(),
+  search: z.string().optional(),
+  featured: z.coerce.boolean().optional(),
+  sortBy: z.enum(['publishedDate', 'createdAt', 'title']).default('publishedDate'),
+  sortOrder: z.enum(['asc', 'desc']).default('desc'),
+});
+
+export type ListArticlesQuery = z.infer<typeof listArticlesQuerySchema>;

--- a/apps/cms/src/api/article/content-types/article/schema.json
+++ b/apps/cms/src/api/article/content-types/article/schema.json
@@ -1,0 +1,56 @@
+{
+  "kind": "collectionType",
+  "collectionName": "articles",
+  "info": {
+    "singularName": "article",
+    "pluralName": "articles",
+    "displayName": "Article",
+    "description": "Editorial content for the platform"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true
+    },
+    "content": {
+      "type": "richtext",
+      "required": true
+    },
+    "excerpt": {
+      "type": "text"
+    },
+    "coverImage": {
+      "type": "media",
+      "multiple": false,
+      "allowedTypes": ["images"]
+    },
+    "author": {
+      "type": "string"
+    },
+    "category": {
+      "type": "enumeration",
+      "enum": [
+        "ARTIST_SPOTLIGHT",
+        "EXHIBITION",
+        "BEHIND_THE_SCENES",
+        "NEWS",
+        "GUIDE"
+      ]
+    },
+    "publishedDate": {
+      "type": "date"
+    },
+    "featured": {
+      "type": "boolean",
+      "default": false
+    }
+  }
+}

--- a/apps/cms/src/api/article/controllers/article.ts
+++ b/apps/cms/src/api/article/controllers/article.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::article.article');

--- a/apps/cms/src/api/article/routes/article.ts
+++ b/apps/cms/src/api/article/routes/article.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::article.article');

--- a/apps/cms/src/api/article/services/article.ts
+++ b/apps/cms/src/api/article/services/article.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::article.article');

--- a/apps/cms/src/api/artist/content-types/artist/schema.json
+++ b/apps/cms/src/api/artist/content-types/artist/schema.json
@@ -1,0 +1,61 @@
+{
+  "kind": "collectionType",
+  "collectionName": "artists",
+  "info": {
+    "singularName": "artist",
+    "pluralName": "artists",
+    "displayName": "Artist",
+    "description": "Artists managed by gallery staff"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "name": {
+      "type": "string",
+      "required": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "name",
+      "required": true
+    },
+    "bio": {
+      "type": "richtext"
+    },
+    "statement": {
+      "type": "richtext"
+    },
+    "location": {
+      "type": "string"
+    },
+    "website": {
+      "type": "string"
+    },
+    "email": {
+      "type": "string"
+    },
+    "phoneNumber": {
+      "type": "string"
+    },
+    "profileImage": {
+      "type": "media",
+      "multiple": false,
+      "allowedTypes": ["images"]
+    },
+    "featured": {
+      "type": "boolean",
+      "default": false
+    },
+    "verified": {
+      "type": "boolean",
+      "default": false
+    },
+    "artworks": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::artwork.artwork",
+      "mappedBy": "artist"
+    }
+  }
+}

--- a/apps/cms/src/api/artist/controllers/artist.ts
+++ b/apps/cms/src/api/artist/controllers/artist.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::artist.artist');

--- a/apps/cms/src/api/artist/routes/artist.ts
+++ b/apps/cms/src/api/artist/routes/artist.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::artist.artist');

--- a/apps/cms/src/api/artist/services/artist.ts
+++ b/apps/cms/src/api/artist/services/artist.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::artist.artist');

--- a/apps/cms/src/api/artwork/content-types/artwork/schema.json
+++ b/apps/cms/src/api/artwork/content-types/artwork/schema.json
@@ -1,0 +1,134 @@
+{
+  "kind": "collectionType",
+  "collectionName": "artworks",
+  "info": {
+    "singularName": "artwork",
+    "pluralName": "artworks",
+    "displayName": "Artwork",
+    "description": "Artworks managed by gallery staff"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true
+    },
+    "description": {
+      "type": "richtext"
+    },
+    "artist": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::artist.artist",
+      "inversedBy": "artworks"
+    },
+    "medium": {
+      "type": "enumeration",
+      "enum": [
+        "PAINTING",
+        "SCULPTURE",
+        "PHOTOGRAPHY",
+        "PRINT",
+        "DRAWING",
+        "MIXED_MEDIA",
+        "DIGITAL",
+        "INSTALLATION",
+        "TEXTILE",
+        "CERAMICS",
+        "GLASS",
+        "METAL",
+        "WOOD",
+        "OTHER"
+      ]
+    },
+    "style": {
+      "type": "enumeration",
+      "enum": [
+        "ABSTRACT",
+        "CONTEMPORARY",
+        "FIGURATIVE",
+        "IMPRESSIONIST",
+        "MINIMALIST",
+        "REALISM",
+        "EXPRESSIONISM",
+        "SURREALISM",
+        "POP_ART",
+        "CONCEPTUAL",
+        "LANDSCAPE",
+        "PORTRAIT",
+        "STILL_LIFE",
+        "OTHER"
+      ]
+    },
+    "year": {
+      "type": "integer"
+    },
+    "width": {
+      "type": "decimal"
+    },
+    "height": {
+      "type": "decimal"
+    },
+    "depth": {
+      "type": "decimal"
+    },
+    "price": {
+      "type": "decimal",
+      "required": true
+    },
+    "currency": {
+      "type": "string",
+      "default": "USD"
+    },
+    "status": {
+      "type": "enumeration",
+      "enum": [
+        "AVAILABLE",
+        "SOLD",
+        "RESERVED",
+        "NOT_FOR_SALE",
+        "ON_LOAN"
+      ],
+      "default": "AVAILABLE"
+    },
+    "featured": {
+      "type": "boolean",
+      "default": false
+    },
+    "edition": {
+      "type": "string"
+    },
+    "materials": {
+      "type": "string"
+    },
+    "signature": {
+      "type": "string"
+    },
+    "certificate": {
+      "type": "boolean",
+      "default": false
+    },
+    "framed": {
+      "type": "boolean",
+      "default": false
+    },
+    "images": {
+      "type": "media",
+      "multiple": true,
+      "allowedTypes": ["images"]
+    },
+    "collections": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::collection.collection",
+      "inversedBy": "artworks"
+    }
+  }
+}

--- a/apps/cms/src/api/artwork/controllers/artwork.ts
+++ b/apps/cms/src/api/artwork/controllers/artwork.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::artwork.artwork');

--- a/apps/cms/src/api/artwork/routes/artwork.ts
+++ b/apps/cms/src/api/artwork/routes/artwork.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::artwork.artwork');

--- a/apps/cms/src/api/artwork/services/artwork.ts
+++ b/apps/cms/src/api/artwork/services/artwork.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::artwork.artwork');

--- a/apps/cms/src/api/collection/content-types/collection/schema.json
+++ b/apps/cms/src/api/collection/content-types/collection/schema.json
@@ -1,0 +1,42 @@
+{
+  "kind": "collectionType",
+  "collectionName": "collections",
+  "info": {
+    "singularName": "collection",
+    "pluralName": "collections",
+    "displayName": "Collection",
+    "description": "Curated collections of artworks"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true
+    },
+    "description": {
+      "type": "richtext"
+    },
+    "coverImage": {
+      "type": "media",
+      "multiple": false,
+      "allowedTypes": ["images"]
+    },
+    "featured": {
+      "type": "boolean",
+      "default": false
+    },
+    "artworks": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::artwork.artwork",
+      "mappedBy": "collections"
+    }
+  }
+}

--- a/apps/cms/src/api/collection/controllers/collection.ts
+++ b/apps/cms/src/api/collection/controllers/collection.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::collection.collection');

--- a/apps/cms/src/api/collection/routes/collection.ts
+++ b/apps/cms/src/api/collection/routes/collection.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::collection.collection');

--- a/apps/cms/src/api/collection/services/collection.ts
+++ b/apps/cms/src/api/collection/services/collection.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::collection.collection');

--- a/apps/web/app/discover/editorial/[slug]/page.tsx
+++ b/apps/web/app/discover/editorial/[slug]/page.tsx
@@ -1,0 +1,243 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import Image from 'next/image';
+import { Container, Section } from '@/components/layout';
+import { Button } from '@/components/ui';
+import {
+  apiClient,
+  type Article,
+  type ArticleCategory,
+} from '@/lib/api-client';
+import { Loader2, Calendar, User, ArrowLeft, ArrowRight } from 'lucide-react';
+
+const categoryColors: Record<ArticleCategory, string> = {
+  ARTIST_SPOTLIGHT: 'bg-purple-100 text-purple-800',
+  EXHIBITION: 'bg-blue-100 text-blue-800',
+  BEHIND_THE_SCENES: 'bg-amber-100 text-amber-800',
+  NEWS: 'bg-green-100 text-green-800',
+  GUIDE: 'bg-teal-100 text-teal-800',
+};
+
+const categoryLabels: Record<ArticleCategory, string> = {
+  ARTIST_SPOTLIGHT: 'Artist Spotlight',
+  EXHIBITION: 'Exhibition',
+  BEHIND_THE_SCENES: 'Behind the Scenes',
+  NEWS: 'News',
+  GUIDE: 'Guide',
+};
+
+function formatDate(dateStr: string | null) {
+  if (!dateStr) return '';
+  return new Date(dateStr).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+export default function ArticleDetailPage() {
+  const params = useParams();
+  const slug = params.slug as string;
+
+  const [article, setArticle] = useState<Article | null>(null);
+  const [relatedArticles, setRelatedArticles] = useState<Article[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!slug) return;
+
+    const fetchArticle = async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const response = await apiClient.getArticle(slug);
+        setArticle(response.data);
+
+        // Fetch related articles (same category)
+        if (response.data.category) {
+          const relatedResponse = await apiClient.getArticles({
+            category: response.data.category,
+            limit: 4,
+            sortBy: 'publishedDate',
+            sortOrder: 'desc',
+          });
+          setRelatedArticles(
+            relatedResponse.data.filter((a) => a.slug !== slug).slice(0, 3)
+          );
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load article');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchArticle();
+  }, [slug]);
+
+  if (loading) {
+    return (
+      <Section spacing="lg">
+        <Container>
+          <div className="flex items-center justify-center py-20">
+            <Loader2 className="w-8 h-8 text-primary-600 animate-spin" />
+          </div>
+        </Container>
+      </Section>
+    );
+  }
+
+  if (error || !article) {
+    return (
+      <Section spacing="lg">
+        <Container>
+          <div className="text-center py-20">
+            <h2 className="text-heading-2 font-serif text-neutral-900 mb-4">
+              {error || 'Article not found'}
+            </h2>
+            <Link href="/discover/editorial">
+              <Button variant="outline">
+                <ArrowLeft className="w-4 h-4 mr-2" />
+                Back to Editorial
+              </Button>
+            </Link>
+          </div>
+        </Container>
+      </Section>
+    );
+  }
+
+  return (
+    <>
+      {/* Hero Cover Image */}
+      {article.coverImageUrl && (
+        <div className="relative h-[300px] md:h-[450px] overflow-hidden">
+          <Image
+            src={article.coverImageUrl}
+            alt={article.title}
+            fill
+            className="object-cover"
+            priority
+          />
+          <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent" />
+        </div>
+      )}
+
+      <Section spacing="lg">
+        <Container size="md">
+          {/* Back Link */}
+          <Link
+            href="/discover/editorial"
+            className="inline-flex items-center gap-1 text-sm text-neutral-500 hover:text-primary-600 transition-colors mb-8"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Back to Editorial
+          </Link>
+
+          {/* Article Header */}
+          <header className="mb-10">
+            {article.category && (
+              <span
+                className={`inline-block px-3 py-1 rounded-full text-xs font-medium mb-4 ${categoryColors[article.category]}`}
+              >
+                {categoryLabels[article.category]}
+              </span>
+            )}
+
+            <h1 className="text-display-lg font-serif text-neutral-900 mb-4">
+              {article.title}
+            </h1>
+
+            {article.excerpt && (
+              <p className="text-body-lg text-neutral-600 mb-6">{article.excerpt}</p>
+            )}
+
+            <div className="flex items-center gap-4 text-sm text-neutral-500 border-b border-neutral-200 pb-6">
+              {article.author && (
+                <span className="flex items-center gap-1.5">
+                  <User className="w-4 h-4" />
+                  {article.author}
+                </span>
+              )}
+              {article.publishedDate && (
+                <span className="flex items-center gap-1.5">
+                  <Calendar className="w-4 h-4" />
+                  {formatDate(article.publishedDate)}
+                </span>
+              )}
+            </div>
+          </header>
+
+          {/* Article Content */}
+          <article
+            className="prose prose-lg prose-neutral max-w-none mb-16
+              prose-headings:font-serif prose-headings:text-neutral-900
+              prose-p:text-neutral-700 prose-p:leading-relaxed
+              prose-a:text-primary-600 prose-a:no-underline hover:prose-a:underline
+              prose-img:rounded-lg"
+            dangerouslySetInnerHTML={{ __html: article.content }}
+          />
+        </Container>
+      </Section>
+
+      {/* Related Articles */}
+      {relatedArticles.length > 0 && (
+        <Section spacing="lg" background="neutral">
+          <Container size="xl">
+            <h2 className="text-heading-2 font-serif text-neutral-900 mb-8">
+              Related Articles
+            </h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+              {relatedArticles.map((related) => (
+                <Link
+                  key={related.id}
+                  href={`/discover/editorial/${related.slug}`}
+                  className="group bg-white rounded-lg overflow-hidden shadow-sm hover:shadow-md transition-shadow"
+                >
+                  <div className="relative aspect-[16/9] overflow-hidden">
+                    {related.coverImageUrl ? (
+                      <Image
+                        src={related.coverImageUrl}
+                        alt={related.title}
+                        fill
+                        className="object-cover transition-transform duration-500 group-hover:scale-105"
+                      />
+                    ) : (
+                      <div className="absolute inset-0 bg-neutral-200" />
+                    )}
+                  </div>
+                  <div className="p-5">
+                    {related.category && (
+                      <span
+                        className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium mb-2 ${categoryColors[related.category]}`}
+                      >
+                        {categoryLabels[related.category]}
+                      </span>
+                    )}
+                    <h3 className="text-heading-4 font-serif text-neutral-900 line-clamp-2 group-hover:text-primary-600 transition-colors">
+                      {related.title}
+                    </h3>
+                    {related.publishedDate && (
+                      <p className="text-sm text-neutral-500 mt-2">
+                        {formatDate(related.publishedDate)}
+                      </p>
+                    )}
+                    <div className="flex items-center gap-1 text-primary-600 text-sm font-medium mt-3">
+                      Read more
+                      <ArrowRight className="w-3.5 h-3.5" />
+                    </div>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </Container>
+        </Section>
+      )}
+    </>
+  );
+}

--- a/apps/web/app/discover/editorial/page.tsx
+++ b/apps/web/app/discover/editorial/page.tsx
@@ -1,0 +1,348 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+import Image from 'next/image';
+import { Container, Section } from '@/components/layout';
+import { SearchInput, Button } from '@/components/ui';
+import {
+  apiClient,
+  type Article,
+  type ArticleCategory,
+  type ArticleFilters,
+} from '@/lib/api-client';
+import { Loader2, Calendar, User, ArrowRight } from 'lucide-react';
+
+const categoryOptions: { value: ArticleCategory | 'ALL'; label: string }[] = [
+  { value: 'ALL', label: 'All' },
+  { value: 'ARTIST_SPOTLIGHT', label: 'Artist Spotlight' },
+  { value: 'EXHIBITION', label: 'Exhibition' },
+  { value: 'BEHIND_THE_SCENES', label: 'Behind the Scenes' },
+  { value: 'NEWS', label: 'News' },
+  { value: 'GUIDE', label: 'Guide' },
+];
+
+const categoryColors: Record<ArticleCategory, string> = {
+  ARTIST_SPOTLIGHT: 'bg-purple-100 text-purple-800',
+  EXHIBITION: 'bg-blue-100 text-blue-800',
+  BEHIND_THE_SCENES: 'bg-amber-100 text-amber-800',
+  NEWS: 'bg-green-100 text-green-800',
+  GUIDE: 'bg-teal-100 text-teal-800',
+};
+
+const categoryLabels: Record<ArticleCategory, string> = {
+  ARTIST_SPOTLIGHT: 'Artist Spotlight',
+  EXHIBITION: 'Exhibition',
+  BEHIND_THE_SCENES: 'Behind the Scenes',
+  NEWS: 'News',
+  GUIDE: 'Guide',
+};
+
+function formatDate(dateStr: string | null) {
+  if (!dateStr) return '';
+  return new Date(dateStr).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+export default function EditorialPage() {
+  const [articles, setArticles] = useState<Article[]>([]);
+  const [featuredArticle, setFeaturedArticle] = useState<Article | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [pagination, setPagination] = useState({
+    page: 1,
+    limit: 12,
+    total: 0,
+    totalPages: 0,
+  });
+
+  const [search, setSearch] = useState('');
+  const [selectedCategory, setSelectedCategory] = useState<ArticleCategory | 'ALL'>('ALL');
+
+  // Fetch featured article on mount
+  useEffect(() => {
+    apiClient
+      .getFeaturedArticles(1)
+      .then((res) => {
+        if (res.data.length > 0) {
+          setFeaturedArticle(res.data[0]);
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  // Fetch articles
+  const fetchArticles = async (page = 1) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const filters: ArticleFilters & { page: number; limit: number } = {
+        page,
+        limit: 12,
+        sortBy: 'publishedDate',
+        sortOrder: 'desc',
+      };
+
+      if (search) filters.search = search;
+      if (selectedCategory !== 'ALL') filters.category = selectedCategory;
+
+      const response = await apiClient.getArticles(filters);
+      setArticles(response.data);
+      if (response.pagination) {
+        setPagination(response.pagination);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load articles');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchArticles(1);
+  }, [search, selectedCategory]);
+
+  return (
+    <>
+      {/* Hero — Featured Article */}
+      {featuredArticle && (
+        <div>
+          <Link
+            href={`/discover/editorial/${featuredArticle.slug}`}
+            className="group block relative h-[400px] md:h-[500px] overflow-hidden"
+          >
+            {featuredArticle.coverImageUrl ? (
+              <Image
+                src={featuredArticle.coverImageUrl}
+                alt={featuredArticle.title}
+                fill
+                className="object-cover transition-transform duration-700 group-hover:scale-105"
+                priority
+              />
+            ) : (
+              <div className="absolute inset-0 bg-neutral-200" />
+            )}
+            <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/30 to-transparent" />
+            <div className="absolute bottom-0 left-0 right-0 p-8 md:p-12">
+              <Container size="xl">
+                <div className="max-w-2xl">
+                  {featuredArticle.category && (
+                    <span
+                      className={`inline-block px-3 py-1 rounded-full text-xs font-medium mb-4 ${categoryColors[featuredArticle.category]}`}
+                    >
+                      {categoryLabels[featuredArticle.category]}
+                    </span>
+                  )}
+                  <h2 className="text-display font-serif text-white mb-3">
+                    {featuredArticle.title}
+                  </h2>
+                  {featuredArticle.excerpt && (
+                    <p className="text-body-lg text-white/80 mb-4 line-clamp-2">
+                      {featuredArticle.excerpt}
+                    </p>
+                  )}
+                  <div className="flex items-center gap-4 text-sm text-white/60">
+                    {featuredArticle.author && (
+                      <span className="flex items-center gap-1">
+                        <User className="w-4 h-4" />
+                        {featuredArticle.author}
+                      </span>
+                    )}
+                    {featuredArticle.publishedDate && (
+                      <span className="flex items-center gap-1">
+                        <Calendar className="w-4 h-4" />
+                        {formatDate(featuredArticle.publishedDate)}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </Container>
+            </div>
+          </Link>
+        </div>
+      )}
+
+      <Section spacing="lg" background="neutral">
+        <Container size="xl">
+          {/* Header */}
+          <div className="mb-8">
+            <h1 className="text-display font-serif text-neutral-900 mb-2">Editorial</h1>
+            <p className="text-body-lg text-neutral-600">
+              Stories, spotlights, and insights from the art world
+            </p>
+          </div>
+
+          {/* Search & Category Filters */}
+          <div className="bg-white rounded-lg p-4 space-y-4 mb-8">
+            <SearchInput
+              value={search}
+              onChange={setSearch}
+              placeholder="Search articles..."
+            />
+            <div className="flex flex-wrap gap-2">
+              {categoryOptions.map((cat) => (
+                <button
+                  key={cat.value}
+                  type="button"
+                  onClick={() => setSelectedCategory(cat.value)}
+                  className={`px-4 py-2 rounded-full text-sm font-medium transition-colors ${
+                    selectedCategory === cat.value
+                      ? 'bg-primary-600 text-white'
+                      : 'bg-neutral-100 text-neutral-700 hover:bg-neutral-200'
+                  }`}
+                >
+                  {cat.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Results summary */}
+          <div className="flex items-center justify-between text-sm text-neutral-600 mb-6">
+            <p>
+              {loading ? (
+                'Loading...'
+              ) : (
+                <>
+                  Showing {articles.length} of {pagination.total} articles
+                </>
+              )}
+            </p>
+          </div>
+
+          {/* Error State */}
+          {error && (
+            <div className="bg-error-50 border border-error-200 rounded-lg p-4 text-error-700 mb-6">
+              {error}
+            </div>
+          )}
+
+          {/* Loading State */}
+          {loading && (
+            <div className="flex items-center justify-center py-20">
+              <Loader2 className="w-8 h-8 text-primary-600 animate-spin" />
+            </div>
+          )}
+
+          {/* Article Grid */}
+          {!loading && !error && (
+            <>
+              {articles.length === 0 ? (
+                <div className="text-center py-20">
+                  <p className="text-neutral-600">No articles found.</p>
+                  {(search || selectedCategory !== 'ALL') && (
+                    <Button
+                      variant="outline"
+                      onClick={() => {
+                        setSearch('');
+                        setSelectedCategory('ALL');
+                      }}
+                      className="mt-4"
+                    >
+                      Clear Filters
+                    </Button>
+                  )}
+                </div>
+              ) : (
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+                  {articles.map((article) => (
+                    <ArticleCard key={article.id} article={article} />
+                  ))}
+                </div>
+              )}
+
+              {/* Pagination */}
+              {pagination.totalPages > 1 && (
+                <div className="flex items-center justify-center gap-2 pt-8">
+                  <Button
+                    variant="outline"
+                    onClick={() => fetchArticles(pagination.page - 1)}
+                    disabled={pagination.page === 1}
+                  >
+                    Previous
+                  </Button>
+                  <span className="px-4 text-sm text-neutral-600">
+                    Page {pagination.page} of {pagination.totalPages}
+                  </span>
+                  <Button
+                    variant="outline"
+                    onClick={() => fetchArticles(pagination.page + 1)}
+                    disabled={pagination.page === pagination.totalPages}
+                  >
+                    Next
+                  </Button>
+                </div>
+              )}
+            </>
+          )}
+        </Container>
+      </Section>
+    </>
+  );
+}
+
+function ArticleCard({ article }: { article: Article }) {
+  return (
+    <Link
+      href={`/discover/editorial/${article.slug}`}
+      className="group bg-white rounded-lg overflow-hidden shadow-sm hover:shadow-md transition-shadow"
+    >
+      {/* Cover Image */}
+      <div className="relative aspect-[16/9] overflow-hidden">
+        {article.coverImageUrl ? (
+          <Image
+            src={article.coverImageUrl}
+            alt={article.title}
+            fill
+            className="object-cover transition-transform duration-500 group-hover:scale-105"
+          />
+        ) : (
+          <div className="absolute inset-0 bg-neutral-200 flex items-center justify-center">
+            <span className="text-neutral-400 text-sm">No image</span>
+          </div>
+        )}
+      </div>
+
+      {/* Content */}
+      <div className="p-5">
+        {article.category && (
+          <span
+            className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium mb-3 ${categoryColors[article.category]}`}
+          >
+            {categoryLabels[article.category]}
+          </span>
+        )}
+
+        <h3 className="text-heading-4 font-serif text-neutral-900 mb-2 line-clamp-2 group-hover:text-primary-600 transition-colors">
+          {article.title}
+        </h3>
+
+        {article.excerpt && (
+          <p className="text-body text-neutral-600 line-clamp-3 mb-4">{article.excerpt}</p>
+        )}
+
+        <div className="flex items-center justify-between text-sm text-neutral-500">
+          <div className="flex items-center gap-3">
+            {article.author && (
+              <span className="flex items-center gap-1">
+                <User className="w-3.5 h-3.5" />
+                {article.author}
+              </span>
+            )}
+            {article.publishedDate && (
+              <span className="flex items-center gap-1">
+                <Calendar className="w-3.5 h-3.5" />
+                {formatDate(article.publishedDate)}
+              </span>
+            )}
+          </div>
+          <ArrowRight className="w-4 h-4 text-primary-600 opacity-0 group-hover:opacity-100 transition-opacity" />
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -189,6 +189,38 @@ export interface RespondInquiryInput {
   status?: 'RESPONDED' | 'CLOSED';
 }
 
+// ── Articles ──────────────────────────────────────────────────────────
+
+export type ArticleCategory =
+  | 'ARTIST_SPOTLIGHT'
+  | 'EXHIBITION'
+  | 'BEHIND_THE_SCENES'
+  | 'NEWS'
+  | 'GUIDE';
+
+export interface Article {
+  id: string;
+  title: string;
+  slug: string;
+  content: string;
+  excerpt: string | null;
+  coverImageUrl: string | null;
+  author: string | null;
+  category: ArticleCategory | null;
+  publishedDate: string | null;
+  featured: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ArticleFilters {
+  category?: ArticleCategory;
+  search?: string;
+  featured?: boolean;
+  sortBy?: 'publishedDate' | 'createdAt' | 'title';
+  sortOrder?: 'asc' | 'desc';
+}
+
 class ApiClient {
   private baseUrl: string;
   private accessToken: string | null = null;
@@ -405,6 +437,32 @@ class ApiClient {
       method: 'PATCH',
       body: JSON.stringify(data),
     });
+  }
+
+  // ── Articles ──────────────────────────────────────────────────────────
+
+  /**
+   * Get list of articles with filtering and pagination
+   */
+  async getArticles(
+    params: ArticleFilters & PaginationParams = {}
+  ): Promise<ApiResponse<Article[]>> {
+    const queryString = this.buildQueryString(params);
+    return this.fetch<Article[]>(`/articles${queryString}`);
+  }
+
+  /**
+   * Get featured articles
+   */
+  async getFeaturedArticles(limit = 6): Promise<ApiResponse<Article[]>> {
+    return this.fetch<Article[]>(`/articles/featured?limit=${limit}`);
+  }
+
+  /**
+   * Get single article by slug
+   */
+  async getArticle(slug: string): Promise<ApiResponse<Article>> {
+    return this.fetch<Article>(`/articles/${slug}`);
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
   apps/api:
     dependencies:
       '@prisma/client':
-        specifier: ^6.3.0
+        specifier: ^6.19.2
         version: 6.19.2(prisma@6.19.2)(typescript@5.9.3)
       '@sendgrid/mail':
         specifier: ^8.1.4
@@ -1658,7 +1658,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -1799,7 +1799,7 @@ packages:
     deprecated: Use @eslint/config-array instead
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -8097,18 +8097,6 @@ packages:
       ms: 2.1.2
     dev: false
 
-  /debug@4.4.3:
-    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.3
-    dev: true
-
   /debug@4.4.3(supports-color@5.5.0):
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -9032,7 +9020,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2


### PR DESCRIPTION
## Summary
- **#42 — Strapi Content Types**: Created artwork, artist, collection, and article content types in `apps/cms/src/api/` with Strapi 5 factory boilerplate and full schema definitions matching existing Prisma models
- **#43 — CMS-to-API Data Sync**: Added `Article` model + `strapiId` fields to Prisma schema, webhook endpoint (`POST /webhooks/cms`) with secret validation, and sync service that maps Strapi lifecycle events to Prisma upserts for all content types
- **#44 — Editorial Frontend**: Added article API endpoints (`GET /articles`, `/articles/featured`, `/articles/:slug`), API client types/methods, editorial listing page at `/discover/editorial` with category filters and pagination, and article detail page with rich text rendering and related articles

## Test plan
- [ ] Verify `tsc --noEmit -p apps/api/tsconfig.json` passes clean
- [ ] Verify Strapi content types load when CMS starts (`pnpm --filter cms run dev`)
- [ ] `POST /webhooks/cms` rejects requests without valid `x-webhook-secret` header
- [ ] `POST /webhooks/cms` with valid secret and mock payload creates/updates records in DB
- [ ] `GET /articles` returns paginated articles
- [ ] `GET /articles/:slug` returns a single article
- [ ] Editorial listing page renders at `/discover/editorial`
- [ ] Article detail page renders rich text content at `/discover/editorial/:slug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)