### PR TITLE
feat: CMS-driven pages, navigation cleanup & 9 new pages

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -356,3 +356,17 @@ enum ArticleCategory {
   NEWS
   GUIDE
 }
+
+// ============================================================================
+// CMS PAGE CONTENT
+// ============================================================================
+
+model PageContent {
+  id        String   @id @default(cuid())
+  slug      String   @unique
+  content   Json
+  updatedAt DateTime @updatedAt
+  createdAt DateTime @default(now())
+
+  @@map("page_contents")
+}

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -14,6 +14,7 @@ import favoritesRouter from './routes/favorites';
 import inquiriesRouter from './routes/inquiries';
 import webhooksRouter from './routes/webhooks';
 import articlesRouter from './routes/articles';
+import pageContentsRouter from './routes/page-contents';
 import { initializeCloudinary } from './config/cloudinary';
 
 // Initialize Cloudinary (skip in test environment)
@@ -58,6 +59,7 @@ app.use('/favorites', favoritesRouter);
 app.use('/inquiries', inquiriesRouter);
 app.use('/webhooks', webhooksRouter);
 app.use('/articles', articlesRouter);
+app.use('/pages', pageContentsRouter);
 
 // 404 handler
 app.use('*', (req, res) => {

--- a/apps/api/src/controllers/page-content.controller.ts
+++ b/apps/api/src/controllers/page-content.controller.ts
@@ -1,0 +1,25 @@
+import { Request, Response, NextFunction } from 'express';
+import { pageContentService } from '../services/page-content.service';
+import { AppError } from '../middleware/error-handler';
+
+export class PageContentController {
+  async getBySlug(req: Request, res: Response, next: NextFunction) {
+    try {
+      const slug = req.params.slug as string;
+      const page = await pageContentService.getBySlug(slug);
+
+      if (!page) {
+        return next(new AppError('Page not found', 404));
+      }
+
+      res.json({
+        success: true,
+        data: page,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+}
+
+export const pageContentController = new PageContentController();

--- a/apps/api/src/routes/page-contents.ts
+++ b/apps/api/src/routes/page-contents.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { pageContentController } from '../controllers/page-content.controller';
+
+const router = Router();
+
+// Get page content by slug
+// GET /pages/:slug
+router.get('/:slug', pageContentController.getBySlug.bind(pageContentController));
+
+export default router;

--- a/apps/api/src/services/cms-sync.service.ts
+++ b/apps/api/src/services/cms-sync.service.ts
@@ -2,8 +2,20 @@ import { prisma } from '../config/database';
 
 type StrapiEvent = 'entry.create' | 'entry.update' | 'entry.delete';
 
+const PAGE_SLUGS: Record<string, string> = {
+  'home-page': 'home',
+  'contact-page': 'contact',
+  'collector-services-page': 'collector-services',
+  'discover-page': 'discover',
+};
+
 export class CmsSyncService {
   async handleEvent(event: StrapiEvent, model: string, entry: any) {
+    // Check if this is a page single type
+    if (PAGE_SLUGS[model]) {
+      return this.syncPageContent(model, entry);
+    }
+
     switch (model) {
       case 'artist':
         return this.syncArtist(event, entry);
@@ -16,6 +28,20 @@ export class CmsSyncService {
       default:
         console.log(`CMS sync: unhandled model "${model}"`);
     }
+  }
+
+  private async syncPageContent(model: string, entry: any) {
+    const slug = PAGE_SLUGS[model];
+    if (!slug) return;
+
+    // Strip Strapi internal fields, keep only content attributes
+    const { id, documentId, createdAt, updatedAt, publishedAt, locale, ...content } = entry;
+
+    await prisma.pageContent.upsert({
+      where: { slug },
+      create: { slug, content },
+      update: { content },
+    });
   }
 
   private async syncArtist(event: StrapiEvent, entry: any) {

--- a/apps/api/src/services/page-content.service.ts
+++ b/apps/api/src/services/page-content.service.ts
@@ -1,0 +1,11 @@
+import { prisma } from '../config/database';
+
+export class PageContentService {
+  async getBySlug(slug: string) {
+    return prisma.pageContent.findUnique({
+      where: { slug },
+    });
+  }
+}
+
+export const pageContentService = new PageContentService();

--- a/apps/cms/src/api/collector-services-page/content-types/collector-services-page/schema.json
+++ b/apps/cms/src/api/collector-services-page/content-types/collector-services-page/schema.json
@@ -1,0 +1,27 @@
+{
+  "kind": "singleType",
+  "collectionName": "collector_services_pages",
+  "info": {
+    "singularName": "collector-services-page",
+    "pluralName": "collector-services-pages",
+    "displayName": "Collector Services Page"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "headline": {
+      "type": "string",
+      "required": true
+    },
+    "subtitle": {
+      "type": "text"
+    },
+    "introContent": {
+      "type": "richtext"
+    },
+    "services": {
+      "type": "json"
+    }
+  }
+}

--- a/apps/cms/src/api/collector-services-page/controllers/collector-services-page.ts
+++ b/apps/cms/src/api/collector-services-page/controllers/collector-services-page.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::collector-services-page.collector-services-page');

--- a/apps/cms/src/api/collector-services-page/routes/collector-services-page.ts
+++ b/apps/cms/src/api/collector-services-page/routes/collector-services-page.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::collector-services-page.collector-services-page');

--- a/apps/cms/src/api/collector-services-page/services/collector-services-page.ts
+++ b/apps/cms/src/api/collector-services-page/services/collector-services-page.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::collector-services-page.collector-services-page');

--- a/apps/cms/src/api/contact-page/content-types/contact-page/schema.json
+++ b/apps/cms/src/api/contact-page/content-types/contact-page/schema.json
@@ -1,0 +1,39 @@
+{
+  "kind": "singleType",
+  "collectionName": "contact_pages",
+  "info": {
+    "singularName": "contact-page",
+    "pluralName": "contact-pages",
+    "displayName": "Contact Page"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "headline": {
+      "type": "string",
+      "required": true
+    },
+    "subtitle": {
+      "type": "text"
+    },
+    "email": {
+      "type": "string"
+    },
+    "phone": {
+      "type": "string"
+    },
+    "address": {
+      "type": "text"
+    },
+    "businessHours": {
+      "type": "text"
+    },
+    "formHeadline": {
+      "type": "string"
+    },
+    "formSubtitle": {
+      "type": "string"
+    }
+  }
+}

--- a/apps/cms/src/api/contact-page/controllers/contact-page.ts
+++ b/apps/cms/src/api/contact-page/controllers/contact-page.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::contact-page.contact-page');

--- a/apps/cms/src/api/contact-page/routes/contact-page.ts
+++ b/apps/cms/src/api/contact-page/routes/contact-page.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::contact-page.contact-page');

--- a/apps/cms/src/api/contact-page/services/contact-page.ts
+++ b/apps/cms/src/api/contact-page/services/contact-page.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::contact-page.contact-page');

--- a/apps/cms/src/api/discover-page/content-types/discover-page/schema.json
+++ b/apps/cms/src/api/discover-page/content-types/discover-page/schema.json
@@ -1,0 +1,21 @@
+{
+  "kind": "singleType",
+  "collectionName": "discover_pages",
+  "info": {
+    "singularName": "discover-page",
+    "pluralName": "discover-pages",
+    "displayName": "Discover Page"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "headline": {
+      "type": "string",
+      "required": true
+    },
+    "subtitle": {
+      "type": "text"
+    }
+  }
+}

--- a/apps/cms/src/api/discover-page/controllers/discover-page.ts
+++ b/apps/cms/src/api/discover-page/controllers/discover-page.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::discover-page.discover-page');

--- a/apps/cms/src/api/discover-page/routes/discover-page.ts
+++ b/apps/cms/src/api/discover-page/routes/discover-page.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::discover-page.discover-page');

--- a/apps/cms/src/api/discover-page/services/discover-page.ts
+++ b/apps/cms/src/api/discover-page/services/discover-page.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::discover-page.discover-page');

--- a/apps/cms/src/api/home-page/content-types/home-page/schema.json
+++ b/apps/cms/src/api/home-page/content-types/home-page/schema.json
@@ -1,0 +1,46 @@
+{
+  "kind": "singleType",
+  "collectionName": "home_pages",
+  "info": {
+    "singularName": "home-page",
+    "pluralName": "home-pages",
+    "displayName": "Home Page"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "heroBadgeText": {
+      "type": "string"
+    },
+    "heroHeadline": {
+      "type": "string",
+      "required": true
+    },
+    "heroSubtitle": {
+      "type": "text",
+      "required": true
+    },
+    "heroPrimaryCta": {
+      "type": "string"
+    },
+    "heroPrimaryCtaLink": {
+      "type": "string"
+    },
+    "heroSecondaryCta": {
+      "type": "string"
+    },
+    "heroSecondaryCtaLink": {
+      "type": "string"
+    },
+    "featuresHeadline": {
+      "type": "string"
+    },
+    "featuresSubtitle": {
+      "type": "string"
+    },
+    "features": {
+      "type": "json"
+    }
+  }
+}

--- a/apps/cms/src/api/home-page/controllers/home-page.ts
+++ b/apps/cms/src/api/home-page/controllers/home-page.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::home-page.home-page');

--- a/apps/cms/src/api/home-page/routes/home-page.ts
+++ b/apps/cms/src/api/home-page/routes/home-page.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::home-page.home-page');

--- a/apps/cms/src/api/home-page/services/home-page.ts
+++ b/apps/cms/src/api/home-page/services/home-page.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::home-page.home-page');

--- a/apps/web/app/account/page.tsx
+++ b/apps/web/app/account/page.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useSession } from 'next-auth/react';
+import Link from 'next/link';
+import { Container, Section } from '@/components/layout';
+import { Button } from '@/components/ui';
+import { User, Heart, MessageSquare, LogIn } from 'lucide-react';
+
+export default function AccountPage() {
+  const { data: session, status } = useSession();
+
+  if (status === 'loading') {
+    return (
+      <Section spacing="lg" background="neutral">
+        <Container size="md" className="text-center py-20">
+          <div className="w-8 h-8 border-2 border-primary-600 border-t-transparent rounded-full animate-spin mx-auto" />
+        </Container>
+      </Section>
+    );
+  }
+
+  if (!session?.user) {
+    return (
+      <Section spacing="lg" background="neutral">
+        <Container size="md" className="text-center py-20">
+          <div className="w-16 h-16 rounded-full bg-neutral-200 flex items-center justify-center mx-auto mb-6">
+            <LogIn className="w-8 h-8 text-neutral-400" />
+          </div>
+          <h1 className="text-heading-1 font-serif text-neutral-900 mb-4">Sign In Required</h1>
+          <p className="text-body-lg text-neutral-600 mb-6">
+            Please sign in to view your account.
+          </p>
+          <Link href="/login">
+            <Button size="lg">Sign In</Button>
+          </Link>
+        </Container>
+      </Section>
+    );
+  }
+
+  return (
+    <Section spacing="lg" background="neutral">
+      <Container size="md">
+        <h1 className="text-display font-serif text-neutral-900 mb-8">My Account</h1>
+
+        {/* Profile Card */}
+        <div className="bg-white rounded-xl p-8 mb-8">
+          <div className="flex items-center gap-6">
+            <div className="w-20 h-20 rounded-full bg-primary-100 flex items-center justify-center flex-shrink-0">
+              <User className="w-10 h-10 text-primary-600" />
+            </div>
+            <div>
+              <h2 className="text-heading-2 font-serif text-neutral-900">
+                {session.user.name || 'Art Collector'}
+              </h2>
+              <p className="text-body text-neutral-600">{session.user.email}</p>
+            </div>
+          </div>
+        </div>
+
+        {/* Quick Links */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+          <Link
+            href="/favorites"
+            className="group bg-white rounded-xl p-6 hover:shadow-md transition-shadow"
+          >
+            <div className="flex items-center gap-4">
+              <div className="w-12 h-12 rounded-full bg-red-50 flex items-center justify-center flex-shrink-0">
+                <Heart className="w-6 h-6 text-red-500" />
+              </div>
+              <div>
+                <h3 className="text-heading-4 font-serif text-neutral-900 group-hover:text-primary-600 transition-colors">
+                  My Favorites
+                </h3>
+                <p className="text-sm text-neutral-600">View your saved artworks</p>
+              </div>
+            </div>
+          </Link>
+
+          <Link
+            href="/artworks"
+            className="group bg-white rounded-xl p-6 hover:shadow-md transition-shadow"
+          >
+            <div className="flex items-center gap-4">
+              <div className="w-12 h-12 rounded-full bg-blue-50 flex items-center justify-center flex-shrink-0">
+                <MessageSquare className="w-6 h-6 text-blue-500" />
+              </div>
+              <div>
+                <h3 className="text-heading-4 font-serif text-neutral-900 group-hover:text-primary-600 transition-colors">
+                  Browse Artworks
+                </h3>
+                <p className="text-sm text-neutral-600">Discover new pieces</p>
+              </div>
+            </div>
+          </Link>
+        </div>
+      </Container>
+    </Section>
+  );
+}

--- a/apps/web/app/artists/featured/page.tsx
+++ b/apps/web/app/artists/featured/page.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Container, Section } from '@/components/layout';
+import { ArtistCard } from '@/components/artist';
+import { Button } from '@/components/ui';
+import { apiClient, type Artist } from '@/lib/api-client';
+import { Loader2 } from 'lucide-react';
+
+export default function FeaturedArtistsPage() {
+  const [artists, setArtists] = useState<Artist[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [pagination, setPagination] = useState({ page: 1, limit: 20, total: 0, totalPages: 0 });
+
+  const fetchArtists = async (page = 1) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await apiClient.getArtists({
+        featured: true,
+        page,
+        limit: 20,
+        sortBy: 'displayOrder',
+        sortOrder: 'asc',
+      });
+      setArtists(response.data);
+      if (response.pagination) setPagination(response.pagination);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load artists');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchArtists(1);
+  }, []);
+
+  return (
+    <Section spacing="lg" background="neutral">
+      <Container size="xl">
+        <div className="mb-8">
+          <h1 className="text-display font-serif text-neutral-900 mb-2">Featured Artists</h1>
+          <p className="text-body-lg text-neutral-600">
+            Exceptional artists hand-selected by our curatorial team
+          </p>
+        </div>
+
+        {error && (
+          <div className="text-center py-20">
+            <p className="text-neutral-600 mb-4">{error}</p>
+            <Button onClick={() => fetchArtists(pagination.page)}>Try Again</Button>
+          </div>
+        )}
+
+        {loading ? (
+          <div className="flex items-center justify-center py-20">
+            <Loader2 className="w-8 h-8 text-primary-600 animate-spin" />
+          </div>
+        ) : artists.length === 0 ? (
+          <div className="text-center py-20">
+            <p className="text-neutral-600">No featured artists yet. Check back soon.</p>
+          </div>
+        ) : (
+          <>
+            <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-8">
+              {artists.map((artist, index) => (
+                <ArtistCard key={artist.id} artist={artist} priority={index < 6} />
+              ))}
+            </div>
+
+            {pagination.totalPages > 1 && (
+              <div className="flex items-center justify-center gap-2 pt-8">
+                <Button
+                  variant="outline"
+                  onClick={() => fetchArtists(pagination.page - 1)}
+                  disabled={pagination.page === 1 || loading}
+                >
+                  Previous
+                </Button>
+                <span className="text-sm text-neutral-600 px-4">
+                  Page {pagination.page} of {pagination.totalPages}
+                </span>
+                <Button
+                  variant="outline"
+                  onClick={() => fetchArtists(pagination.page + 1)}
+                  disabled={pagination.page === pagination.totalPages || loading}
+                >
+                  Next
+                </Button>
+              </div>
+            )}
+          </>
+        )}
+      </Container>
+    </Section>
+  );
+}

--- a/apps/web/app/collections/museum-quality/page.tsx
+++ b/apps/web/app/collections/museum-quality/page.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Container, Section } from '@/components/layout';
+import { CollectionCard } from '@/components/collection';
+import { Button } from '@/components/ui';
+import { apiClient, type Collection } from '@/lib/api-client';
+import { Loader2 } from 'lucide-react';
+
+export default function MuseumQualityPage() {
+  const [collections, setCollections] = useState<Collection[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [pagination, setPagination] = useState({ page: 1, limit: 20, total: 0, totalPages: 0 });
+
+  const fetchCollections = async (page = 1) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await apiClient.getCollections({
+        featured: true,
+        page,
+        limit: 20,
+        sortBy: 'displayOrder',
+        sortOrder: 'asc',
+      });
+      setCollections(response.data);
+      if (response.pagination) setPagination(response.pagination);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load collections');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchCollections(1);
+  }, []);
+
+  return (
+    <Section spacing="lg" background="neutral">
+      <Container size="xl">
+        <div className="mb-8">
+          <h1 className="text-display font-serif text-neutral-900 mb-2">Museum-Quality Works</h1>
+          <p className="text-body-lg text-neutral-600">
+            Our finest curated collections, selected to institutional standards
+          </p>
+        </div>
+
+        {error && (
+          <div className="text-center py-20">
+            <p className="text-neutral-600 mb-4">{error}</p>
+            <Button onClick={() => fetchCollections(pagination.page)}>Try Again</Button>
+          </div>
+        )}
+
+        {loading ? (
+          <div className="flex items-center justify-center py-20">
+            <Loader2 className="w-8 h-8 text-primary-600 animate-spin" />
+          </div>
+        ) : collections.length === 0 ? (
+          <div className="text-center py-20">
+            <p className="text-neutral-600">No museum-quality collections yet. Check back soon.</p>
+          </div>
+        ) : (
+          <>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+              {collections.map((collection, index) => (
+                <CollectionCard key={collection.id} collection={collection} priority={index < 6} />
+              ))}
+            </div>
+
+            {pagination.totalPages > 1 && (
+              <div className="flex items-center justify-center gap-2 pt-8">
+                <Button
+                  variant="outline"
+                  onClick={() => fetchCollections(pagination.page - 1)}
+                  disabled={pagination.page === 1 || loading}
+                >
+                  Previous
+                </Button>
+                <span className="text-sm text-neutral-600 px-4">
+                  Page {pagination.page} of {pagination.totalPages}
+                </span>
+                <Button
+                  variant="outline"
+                  onClick={() => fetchCollections(pagination.page + 1)}
+                  disabled={pagination.page === pagination.totalPages || loading}
+                >
+                  Next
+                </Button>
+              </div>
+            )}
+          </>
+        )}
+      </Container>
+    </Section>
+  );
+}

--- a/apps/web/app/collections/new-arrivals/page.tsx
+++ b/apps/web/app/collections/new-arrivals/page.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Container, Section } from '@/components/layout';
+import { CollectionCard } from '@/components/collection';
+import { Button } from '@/components/ui';
+import { apiClient, type Collection } from '@/lib/api-client';
+import { Loader2 } from 'lucide-react';
+
+export default function NewArrivalsPage() {
+  const [collections, setCollections] = useState<Collection[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [pagination, setPagination] = useState({ page: 1, limit: 20, total: 0, totalPages: 0 });
+
+  const fetchCollections = async (page = 1) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await apiClient.getCollections({
+        page,
+        limit: 20,
+        sortBy: 'createdAt',
+        sortOrder: 'desc',
+      });
+      setCollections(response.data);
+      if (response.pagination) setPagination(response.pagination);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load collections');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchCollections(1);
+  }, []);
+
+  return (
+    <Section spacing="lg" background="neutral">
+      <Container size="xl">
+        <div className="mb-8">
+          <h1 className="text-display font-serif text-neutral-900 mb-2">New Arrivals</h1>
+          <p className="text-body-lg text-neutral-600">
+            The latest collections added to our curated selection
+          </p>
+        </div>
+
+        {error && (
+          <div className="text-center py-20">
+            <p className="text-neutral-600 mb-4">{error}</p>
+            <Button onClick={() => fetchCollections(pagination.page)}>Try Again</Button>
+          </div>
+        )}
+
+        {loading ? (
+          <div className="flex items-center justify-center py-20">
+            <Loader2 className="w-8 h-8 text-primary-600 animate-spin" />
+          </div>
+        ) : collections.length === 0 ? (
+          <div className="text-center py-20">
+            <p className="text-neutral-600">No collections yet. Check back soon.</p>
+          </div>
+        ) : (
+          <>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+              {collections.map((collection, index) => (
+                <CollectionCard key={collection.id} collection={collection} priority={index < 6} />
+              ))}
+            </div>
+
+            {pagination.totalPages > 1 && (
+              <div className="flex items-center justify-center gap-2 pt-8">
+                <Button
+                  variant="outline"
+                  onClick={() => fetchCollections(pagination.page - 1)}
+                  disabled={pagination.page === 1 || loading}
+                >
+                  Previous
+                </Button>
+                <span className="text-sm text-neutral-600 px-4">
+                  Page {pagination.page} of {pagination.totalPages}
+                </span>
+                <Button
+                  variant="outline"
+                  onClick={() => fetchCollections(pagination.page + 1)}
+                  disabled={pagination.page === pagination.totalPages || loading}
+                >
+                  Next
+                </Button>
+              </div>
+            )}
+          </>
+        )}
+      </Container>
+    </Section>
+  );
+}

--- a/apps/web/app/collector-services/page.tsx
+++ b/apps/web/app/collector-services/page.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+import { Container, Section } from '@/components/layout';
+import { Button } from '@/components/ui';
+import { apiClient } from '@/lib/api-client';
+
+const DEFAULTS = {
+  headline: 'Collector Services',
+  subtitle: 'Personalized assistance for discerning collectors at every stage of their journey.',
+  introContent: '',
+  services: [
+    {
+      icon: '🔍',
+      title: 'Art Advisory',
+      description: 'Our expert advisors help you discover and acquire works that align with your vision, taste, and investment goals.',
+    },
+    {
+      icon: '✓',
+      title: 'Authentication & Provenance',
+      description: 'Comprehensive verification services to ensure the authenticity and documented history of every piece.',
+    },
+    {
+      icon: '🛡️',
+      title: 'Insurance Guidance',
+      description: 'Professional guidance on insuring your collection with specialized fine art insurance partners.',
+    },
+    {
+      icon: '📦',
+      title: 'White-Glove Shipping',
+      description: 'Museum-standard packing, crating, and delivery for safe transportation of your artworks worldwide.',
+    },
+    {
+      icon: '🖼️',
+      title: 'Installation & Framing',
+      description: 'Expert installation and custom framing services to present your collection at its finest.',
+    },
+    {
+      icon: '📋',
+      title: 'Collection Management',
+      description: 'Digital cataloguing, condition reporting, and strategic planning for your growing collection.',
+    },
+  ],
+};
+
+export default function CollectorServicesPage() {
+  const [content, setContent] = useState(DEFAULTS);
+
+  useEffect(() => {
+    apiClient
+      .getPageContent('collector-services')
+      .then((res) => setContent({ ...DEFAULTS, ...res.data.content }))
+      .catch(() => {});
+  }, []);
+
+  const services = Array.isArray(content.services) ? content.services : DEFAULTS.services;
+
+  return (
+    <>
+      <Section spacing="lg" background="neutral">
+        <Container size="xl">
+          {/* Header */}
+          <div className="text-center mb-12">
+            <h1 className="text-display font-serif text-neutral-900 mb-4">{content.headline}</h1>
+            <p className="text-body-lg text-neutral-600 max-w-2xl mx-auto">{content.subtitle}</p>
+          </div>
+
+          {/* Intro content */}
+          {content.introContent && (
+            <div
+              className="prose prose-neutral mx-auto mb-12 max-w-3xl"
+              dangerouslySetInnerHTML={{ __html: content.introContent }}
+            />
+          )}
+
+          {/* Services Grid */}
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mb-12">
+            {services.map((service: any) => (
+              <div key={service.title} className="bg-white rounded-xl p-8 space-y-4">
+                <div className="w-14 h-14 rounded-full bg-primary-100 flex items-center justify-center">
+                  <span className="text-2xl">{service.icon}</span>
+                </div>
+                <h3 className="text-heading-3 font-serif text-neutral-900">{service.title}</h3>
+                <p className="text-body text-neutral-600">{service.description}</p>
+              </div>
+            ))}
+          </div>
+
+          {/* CTA */}
+          <div className="text-center bg-white rounded-xl p-12">
+            <h2 className="text-heading-2 font-serif text-neutral-900 mb-4">
+              Ready to Start Your Collection Journey?
+            </h2>
+            <p className="text-body-lg text-neutral-600 mb-6 max-w-xl mx-auto">
+              Get in touch with our team to discuss how we can help you build and manage your art collection.
+            </p>
+            <Link href="/contact">
+              <Button size="lg">Contact Us</Button>
+            </Link>
+          </div>
+        </Container>
+      </Section>
+    </>
+  );
+}

--- a/apps/web/app/contact/page.tsx
+++ b/apps/web/app/contact/page.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Container, Section } from '@/components/layout';
+import { Input, Textarea, Button } from '@/components/ui';
+import { apiClient } from '@/lib/api-client';
+import { Mail, Phone, MapPin, Clock } from 'lucide-react';
+
+const DEFAULTS = {
+  headline: 'Contact Us',
+  subtitle: 'We would love to hear from you. Reach out to our team for any inquiries about artworks, services, or collaboration.',
+  email: 'hello@artspot.com',
+  phone: '+1 (555) 000-0000',
+  address: '123 Gallery Street\nNew York, NY 10001',
+  businessHours: 'Monday – Friday: 9am – 6pm\nSaturday: 10am – 4pm\nSunday: Closed',
+  formHeadline: 'Send Us a Message',
+  formSubtitle: 'Fill out the form below and we will get back to you within 24 hours.',
+};
+
+export default function ContactPage() {
+  const [content, setContent] = useState(DEFAULTS);
+  const [formData, setFormData] = useState({ name: '', email: '', subject: '', message: '' });
+
+  useEffect(() => {
+    apiClient
+      .getPageContent('contact')
+      .then((res) => setContent({ ...DEFAULTS, ...res.data.content }))
+      .catch(() => {});
+  }, []);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const subject = encodeURIComponent(formData.subject || 'Inquiry from ArtSpot');
+    const body = encodeURIComponent(`Name: ${formData.name}\nEmail: ${formData.email}\n\n${formData.message}`);
+    window.location.href = `mailto:${content.email}?subject=${subject}&body=${body}`;
+  };
+
+  return (
+    <Section spacing="lg" background="neutral">
+      <Container size="xl">
+        {/* Header */}
+        <div className="text-center mb-12">
+          <h1 className="text-display font-serif text-neutral-900 mb-4">{content.headline}</h1>
+          <p className="text-body-lg text-neutral-600 max-w-2xl mx-auto">{content.subtitle}</p>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-12">
+          {/* Contact Info */}
+          <div className="space-y-8">
+            <div className="bg-white rounded-xl p-8 space-y-6">
+              <div className="flex items-start gap-4">
+                <div className="w-10 h-10 rounded-full bg-primary-100 flex items-center justify-center flex-shrink-0">
+                  <Mail className="w-5 h-5 text-primary-600" />
+                </div>
+                <div>
+                  <h3 className="text-heading-4 font-serif text-neutral-900 mb-1">Email</h3>
+                  <a href={`mailto:${content.email}`} className="text-body text-primary-600 hover:text-primary-700">
+                    {content.email}
+                  </a>
+                </div>
+              </div>
+
+              <div className="flex items-start gap-4">
+                <div className="w-10 h-10 rounded-full bg-primary-100 flex items-center justify-center flex-shrink-0">
+                  <Phone className="w-5 h-5 text-primary-600" />
+                </div>
+                <div>
+                  <h3 className="text-heading-4 font-serif text-neutral-900 mb-1">Phone</h3>
+                  <p className="text-body text-neutral-600">{content.phone}</p>
+                </div>
+              </div>
+
+              <div className="flex items-start gap-4">
+                <div className="w-10 h-10 rounded-full bg-primary-100 flex items-center justify-center flex-shrink-0">
+                  <MapPin className="w-5 h-5 text-primary-600" />
+                </div>
+                <div>
+                  <h3 className="text-heading-4 font-serif text-neutral-900 mb-1">Address</h3>
+                  <p className="text-body text-neutral-600 whitespace-pre-line">{content.address}</p>
+                </div>
+              </div>
+
+              <div className="flex items-start gap-4">
+                <div className="w-10 h-10 rounded-full bg-primary-100 flex items-center justify-center flex-shrink-0">
+                  <Clock className="w-5 h-5 text-primary-600" />
+                </div>
+                <div>
+                  <h3 className="text-heading-4 font-serif text-neutral-900 mb-1">Business Hours</h3>
+                  <p className="text-body text-neutral-600 whitespace-pre-line">{content.businessHours}</p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Contact Form */}
+          <div className="bg-white rounded-xl p-8">
+            <h2 className="text-heading-2 font-serif text-neutral-900 mb-2">{content.formHeadline}</h2>
+            <p className="text-body text-neutral-600 mb-6">{content.formSubtitle}</p>
+
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div>
+                  <label htmlFor="name" className="block text-sm font-medium text-neutral-700 mb-1">Name</label>
+                  <Input
+                    id="name"
+                    value={formData.name}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => setFormData({ ...formData, name: e.target.value })}
+                    required
+                  />
+                </div>
+                <div>
+                  <label htmlFor="email" className="block text-sm font-medium text-neutral-700 mb-1">Email</label>
+                  <Input
+                    id="email"
+                    type="email"
+                    value={formData.email}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => setFormData({ ...formData, email: e.target.value })}
+                    required
+                  />
+                </div>
+              </div>
+
+              <div>
+                <label htmlFor="subject" className="block text-sm font-medium text-neutral-700 mb-1">Subject</label>
+                <Input
+                  id="subject"
+                  value={formData.subject}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => setFormData({ ...formData, subject: e.target.value })}
+                />
+              </div>
+
+              <div>
+                <label htmlFor="message" className="block text-sm font-medium text-neutral-700 mb-1">Message</label>
+                <Textarea
+                  id="message"
+                  rows={5}
+                  value={formData.message}
+                  onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setFormData({ ...formData, message: e.target.value })}
+                  required
+                />
+              </div>
+
+              <Button type="submit" size="lg" className="w-full">Send Message</Button>
+            </form>
+          </div>
+        </div>
+      </Container>
+    </Section>
+  );
+}

--- a/apps/web/app/discover/exhibitions/page.tsx
+++ b/apps/web/app/discover/exhibitions/page.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+import Image from 'next/image';
+import { Container, Section } from '@/components/layout';
+import { Button } from '@/components/ui';
+import { apiClient, type Article } from '@/lib/api-client';
+import { Loader2, Calendar, User, ArrowRight } from 'lucide-react';
+
+function formatDate(dateStr: string | null) {
+  if (!dateStr) return '';
+  return new Date(dateStr).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+export default function ExhibitionsPage() {
+  const [articles, setArticles] = useState<Article[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [pagination, setPagination] = useState({ page: 1, limit: 12, total: 0, totalPages: 0 });
+
+  const fetchArticles = async (page = 1) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await apiClient.getArticles({
+        category: 'EXHIBITION',
+        page,
+        limit: 12,
+        sortBy: 'publishedDate',
+        sortOrder: 'desc',
+      });
+      setArticles(response.data);
+      if (response.pagination) setPagination(response.pagination);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load articles');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchArticles(1);
+  }, []);
+
+  return (
+    <Section spacing="lg" background="neutral">
+      <Container size="xl">
+        <div className="mb-8">
+          <h1 className="text-display font-serif text-neutral-900 mb-2">Exhibitions</h1>
+          <p className="text-body-lg text-neutral-600">
+            Current and upcoming exhibitions featuring our artists
+          </p>
+        </div>
+
+        {error && (
+          <div className="bg-error-50 border border-error-200 rounded-lg p-4 text-error-700 mb-6">{error}</div>
+        )}
+
+        {loading ? (
+          <div className="flex items-center justify-center py-20">
+            <Loader2 className="w-8 h-8 text-primary-600 animate-spin" />
+          </div>
+        ) : articles.length === 0 ? (
+          <div className="text-center py-20">
+            <p className="text-neutral-600">No exhibition articles yet. Check back soon.</p>
+          </div>
+        ) : (
+          <>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+              {articles.map((article) => (
+                <Link
+                  key={article.id}
+                  href={`/discover/editorial/${article.slug}`}
+                  className="group bg-white rounded-lg overflow-hidden shadow-sm hover:shadow-md transition-shadow"
+                >
+                  <div className="relative aspect-[16/9] overflow-hidden">
+                    {article.coverImageUrl ? (
+                      <Image
+                        src={article.coverImageUrl}
+                        alt={article.title}
+                        fill
+                        className="object-cover transition-transform duration-500 group-hover:scale-105"
+                      />
+                    ) : (
+                      <div className="absolute inset-0 bg-neutral-200 flex items-center justify-center">
+                        <span className="text-neutral-400 text-sm">No image</span>
+                      </div>
+                    )}
+                  </div>
+                  <div className="p-5">
+                    <h3 className="text-heading-4 font-serif text-neutral-900 mb-2 line-clamp-2 group-hover:text-primary-600 transition-colors">
+                      {article.title}
+                    </h3>
+                    {article.excerpt && (
+                      <p className="text-body text-neutral-600 line-clamp-3 mb-4">{article.excerpt}</p>
+                    )}
+                    <div className="flex items-center justify-between text-sm text-neutral-500">
+                      <div className="flex items-center gap-3">
+                        {article.author && (
+                          <span className="flex items-center gap-1">
+                            <User className="w-3.5 h-3.5" />
+                            {article.author}
+                          </span>
+                        )}
+                        {article.publishedDate && (
+                          <span className="flex items-center gap-1">
+                            <Calendar className="w-3.5 h-3.5" />
+                            {formatDate(article.publishedDate)}
+                          </span>
+                        )}
+                      </div>
+                      <ArrowRight className="w-4 h-4 text-primary-600 opacity-0 group-hover:opacity-100 transition-opacity" />
+                    </div>
+                  </div>
+                </Link>
+              ))}
+            </div>
+
+            {pagination.totalPages > 1 && (
+              <div className="flex items-center justify-center gap-2 pt-8">
+                <Button
+                  variant="outline"
+                  onClick={() => fetchArticles(pagination.page - 1)}
+                  disabled={pagination.page === 1}
+                >
+                  Previous
+                </Button>
+                <span className="px-4 text-sm text-neutral-600">
+                  Page {pagination.page} of {pagination.totalPages}
+                </span>
+                <Button
+                  variant="outline"
+                  onClick={() => fetchArticles(pagination.page + 1)}
+                  disabled={pagination.page === pagination.totalPages}
+                >
+                  Next
+                </Button>
+              </div>
+            )}
+          </>
+        )}
+      </Container>
+    </Section>
+  );
+}

--- a/apps/web/app/discover/inspiration/page.tsx
+++ b/apps/web/app/discover/inspiration/page.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+import Image from 'next/image';
+import { Container, Section } from '@/components/layout';
+import { Button } from '@/components/ui';
+import { apiClient, type Article } from '@/lib/api-client';
+import { Loader2, Calendar, User, ArrowRight } from 'lucide-react';
+
+function formatDate(dateStr: string | null) {
+  if (!dateStr) return '';
+  return new Date(dateStr).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+export default function InspirationPage() {
+  const [articles, setArticles] = useState<Article[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [pagination, setPagination] = useState({ page: 1, limit: 12, total: 0, totalPages: 0 });
+
+  const fetchArticles = async (page = 1) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await apiClient.getArticles({
+        category: 'BEHIND_THE_SCENES',
+        page,
+        limit: 12,
+        sortBy: 'publishedDate',
+        sortOrder: 'desc',
+      });
+      setArticles(response.data);
+      if (response.pagination) setPagination(response.pagination);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load articles');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchArticles(1);
+  }, []);
+
+  return (
+    <Section spacing="lg" background="neutral">
+      <Container size="xl">
+        <div className="mb-8">
+          <h1 className="text-display font-serif text-neutral-900 mb-2">Inspiration</h1>
+          <p className="text-body-lg text-neutral-600">
+            Behind-the-scenes stories and creative insights from our artists
+          </p>
+        </div>
+
+        {error && (
+          <div className="bg-error-50 border border-error-200 rounded-lg p-4 text-error-700 mb-6">{error}</div>
+        )}
+
+        {loading ? (
+          <div className="flex items-center justify-center py-20">
+            <Loader2 className="w-8 h-8 text-primary-600 animate-spin" />
+          </div>
+        ) : articles.length === 0 ? (
+          <div className="text-center py-20">
+            <p className="text-neutral-600">No inspiration articles yet. Check back soon.</p>
+          </div>
+        ) : (
+          <>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+              {articles.map((article) => (
+                <Link
+                  key={article.id}
+                  href={`/discover/editorial/${article.slug}`}
+                  className="group bg-white rounded-lg overflow-hidden shadow-sm hover:shadow-md transition-shadow"
+                >
+                  <div className="relative aspect-[16/9] overflow-hidden">
+                    {article.coverImageUrl ? (
+                      <Image
+                        src={article.coverImageUrl}
+                        alt={article.title}
+                        fill
+                        className="object-cover transition-transform duration-500 group-hover:scale-105"
+                      />
+                    ) : (
+                      <div className="absolute inset-0 bg-neutral-200 flex items-center justify-center">
+                        <span className="text-neutral-400 text-sm">No image</span>
+                      </div>
+                    )}
+                  </div>
+                  <div className="p-5">
+                    <h3 className="text-heading-4 font-serif text-neutral-900 mb-2 line-clamp-2 group-hover:text-primary-600 transition-colors">
+                      {article.title}
+                    </h3>
+                    {article.excerpt && (
+                      <p className="text-body text-neutral-600 line-clamp-3 mb-4">{article.excerpt}</p>
+                    )}
+                    <div className="flex items-center justify-between text-sm text-neutral-500">
+                      <div className="flex items-center gap-3">
+                        {article.author && (
+                          <span className="flex items-center gap-1">
+                            <User className="w-3.5 h-3.5" />
+                            {article.author}
+                          </span>
+                        )}
+                        {article.publishedDate && (
+                          <span className="flex items-center gap-1">
+                            <Calendar className="w-3.5 h-3.5" />
+                            {formatDate(article.publishedDate)}
+                          </span>
+                        )}
+                      </div>
+                      <ArrowRight className="w-4 h-4 text-primary-600 opacity-0 group-hover:opacity-100 transition-opacity" />
+                    </div>
+                  </div>
+                </Link>
+              ))}
+            </div>
+
+            {pagination.totalPages > 1 && (
+              <div className="flex items-center justify-center gap-2 pt-8">
+                <Button
+                  variant="outline"
+                  onClick={() => fetchArticles(pagination.page - 1)}
+                  disabled={pagination.page === 1}
+                >
+                  Previous
+                </Button>
+                <span className="px-4 text-sm text-neutral-600">
+                  Page {pagination.page} of {pagination.totalPages}
+                </span>
+                <Button
+                  variant="outline"
+                  onClick={() => fetchArticles(pagination.page + 1)}
+                  disabled={pagination.page === pagination.totalPages}
+                >
+                  Next
+                </Button>
+              </div>
+            )}
+          </>
+        )}
+      </Container>
+    </Section>
+  );
+}

--- a/apps/web/app/discover/page.tsx
+++ b/apps/web/app/discover/page.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+import Image from 'next/image';
+import { Container, Section } from '@/components/layout';
+import { Button } from '@/components/ui';
+import { apiClient, type Article } from '@/lib/api-client';
+import { ArrowRight, Calendar, User, Loader2 } from 'lucide-react';
+
+const DEFAULTS = {
+  headline: 'Discover',
+  subtitle: 'Explore the world of art through our editorial content, exhibitions, and curated inspiration.',
+};
+
+const sections = [
+  {
+    title: 'Editorial',
+    description: 'Stories, spotlights, and insights from the art world',
+    href: '/discover/editorial',
+  },
+  {
+    title: 'Inspiration',
+    description: 'Behind-the-scenes looks at artists and their creative process',
+    href: '/discover/inspiration',
+  },
+  {
+    title: 'Exhibitions',
+    description: 'Current and upcoming exhibitions featuring our artists',
+    href: '/discover/exhibitions',
+  },
+];
+
+function formatDate(dateStr: string | null) {
+  if (!dateStr) return '';
+  return new Date(dateStr).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+export default function DiscoverPage() {
+  const [content, setContent] = useState(DEFAULTS);
+  const [articles, setArticles] = useState<Article[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    apiClient
+      .getPageContent('discover')
+      .then((res) => setContent({ ...DEFAULTS, ...res.data.content }))
+      .catch(() => {});
+
+    apiClient
+      .getFeaturedArticles(6)
+      .then((res) => setArticles(res.data))
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <>
+      <Section spacing="lg" background="neutral">
+        <Container size="xl">
+          {/* Header */}
+          <div className="text-center mb-12">
+            <h1 className="text-display font-serif text-neutral-900 mb-4">{content.headline}</h1>
+            <p className="text-body-lg text-neutral-600 max-w-2xl mx-auto">{content.subtitle}</p>
+          </div>
+
+          {/* Section Cards */}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-16">
+            {sections.map((section) => (
+              <Link
+                key={section.title}
+                href={section.href}
+                className="group bg-white rounded-xl p-8 hover:shadow-md transition-shadow"
+              >
+                <h3 className="text-heading-3 font-serif text-neutral-900 mb-2 group-hover:text-primary-600 transition-colors">
+                  {section.title}
+                </h3>
+                <p className="text-body text-neutral-600 mb-4">{section.description}</p>
+                <span className="inline-flex items-center gap-1 text-sm font-medium text-primary-600">
+                  Explore <ArrowRight className="w-4 h-4" />
+                </span>
+              </Link>
+            ))}
+          </div>
+
+          {/* Featured Articles */}
+          <div className="mb-8">
+            <h2 className="text-heading-1 font-serif text-neutral-900 mb-2">Featured Stories</h2>
+            <p className="text-body-lg text-neutral-600">Highlights from our editorial team</p>
+          </div>
+
+          {loading ? (
+            <div className="flex items-center justify-center py-20">
+              <Loader2 className="w-8 h-8 text-primary-600 animate-spin" />
+            </div>
+          ) : articles.length === 0 ? (
+            <div className="text-center py-12">
+              <p className="text-neutral-600">No featured articles yet. Check back soon.</p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+              {articles.map((article) => (
+                <Link
+                  key={article.id}
+                  href={`/discover/editorial/${article.slug}`}
+                  className="group bg-white rounded-lg overflow-hidden shadow-sm hover:shadow-md transition-shadow"
+                >
+                  <div className="relative aspect-[16/9] overflow-hidden">
+                    {article.coverImageUrl ? (
+                      <Image
+                        src={article.coverImageUrl}
+                        alt={article.title}
+                        fill
+                        className="object-cover transition-transform duration-500 group-hover:scale-105"
+                      />
+                    ) : (
+                      <div className="absolute inset-0 bg-neutral-200 flex items-center justify-center">
+                        <span className="text-neutral-400 text-sm">No image</span>
+                      </div>
+                    )}
+                  </div>
+                  <div className="p-5">
+                    <h3 className="text-heading-4 font-serif text-neutral-900 mb-2 line-clamp-2 group-hover:text-primary-600 transition-colors">
+                      {article.title}
+                    </h3>
+                    {article.excerpt && (
+                      <p className="text-body text-neutral-600 line-clamp-2 mb-3">{article.excerpt}</p>
+                    )}
+                    <div className="flex items-center gap-3 text-sm text-neutral-500">
+                      {article.author && (
+                        <span className="flex items-center gap-1">
+                          <User className="w-3.5 h-3.5" />
+                          {article.author}
+                        </span>
+                      )}
+                      {article.publishedDate && (
+                        <span className="flex items-center gap-1">
+                          <Calendar className="w-3.5 h-3.5" />
+                          {formatDate(article.publishedDate)}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          )}
+
+          {/* View all link */}
+          {articles.length > 0 && (
+            <div className="text-center mt-8">
+              <Link href="/discover/editorial">
+                <Button variant="outline" size="lg">View All Articles</Button>
+              </Link>
+            </div>
+          )}
+        </Container>
+      </Section>
+    </>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,8 +1,60 @@
+'use client';
+
+import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { Button } from '@/components/ui';
 import { Container, Section } from '@/components/layout';
+import { apiClient } from '@/lib/api-client';
+
+const DEFAULTS = {
+  heroBadgeText: 'Platform in Development — Phase 1',
+  heroHeadline: 'Discover Museum-Quality Art',
+  heroSubtitle:
+    'Elevating the experience of collecting art online. We believe collecting art goes beyond ownership—it is valued as a personal, intellectual, and emotional asset.',
+  heroPrimaryCta: 'Explore Collection',
+  heroPrimaryCtaLink: '/artworks',
+  heroSecondaryCta: 'Browse Artists',
+  heroSecondaryCtaLink: '/artists',
+  featuresHeadline: 'Why Collectors Choose ArtSpot',
+  featuresSubtitle: 'A premium platform designed for serious art collectors',
+  features: [
+    {
+      icon: '🎨',
+      title: 'Curated Selection',
+      description:
+        'Every artwork is carefully selected by our team of art experts guided by institutional standards.',
+    },
+    {
+      icon: '✓',
+      title: 'Authenticity Guaranteed',
+      description:
+        'Certificates of authenticity and provenance for all works based on honesty and trust.',
+    },
+    {
+      icon: '🤝',
+      title: 'Collector Services',
+      description:
+        'Personalized assistance and art advisory services for discerning collectors.',
+    },
+  ],
+};
 
 export default function HomePage() {
+  const [content, setContent] = useState(DEFAULTS);
+
+  useEffect(() => {
+    apiClient
+      .getPageContent('home')
+      .then((res) => {
+        setContent({ ...DEFAULTS, ...res.data.content });
+      })
+      .catch(() => {
+        // CMS unreachable — keep defaults
+      });
+  }, []);
+
+  const features = Array.isArray(content.features) ? content.features : DEFAULTS.features;
+
   return (
     <>
       {/* Hero Section */}
@@ -11,26 +63,27 @@ export default function HomePage() {
         className="relative flex items-center justify-center bg-gradient-to-br from-neutral-100 to-neutral-50"
       >
         <Container size="md" className="text-center space-y-8">
-          <div className="inline-flex items-center gap-3 px-6 py-3 bg-primary-50 border border-primary-200 rounded-full">
-            <div className="w-2 h-2 bg-primary-500 rounded-full animate-pulse" />
-            <span className="text-sm font-medium text-primary-700">
-              Platform in Development — Phase 1
-            </span>
-          </div>
+          {content.heroBadgeText && (
+            <div className="inline-flex items-center gap-3 px-6 py-3 bg-primary-50 border border-primary-200 rounded-full">
+              <div className="w-2 h-2 bg-primary-500 rounded-full animate-pulse" />
+              <span className="text-sm font-medium text-primary-700">
+                {content.heroBadgeText}
+              </span>
+            </div>
+          )}
 
           <h1 className="text-display-lg font-serif text-neutral-900">
-            Discover Museum-Quality Art
+            {content.heroHeadline}
           </h1>
           <p className="text-body-lg text-neutral-600 max-w-2xl mx-auto leading-relaxed">
-            Elevating the experience of collecting art online. We believe collecting art
-            goes beyond ownership—it is valued as a personal, intellectual, and emotional asset.
+            {content.heroSubtitle}
           </p>
           <div className="flex gap-4 justify-center flex-wrap">
-            <Link href="/artworks">
-              <Button size="lg">Explore Collection</Button>
+            <Link href={content.heroPrimaryCtaLink}>
+              <Button size="lg">{content.heroPrimaryCta}</Button>
             </Link>
-            <Link href="/artists">
-              <Button size="lg" variant="outline">Browse Artists</Button>
+            <Link href={content.heroSecondaryCtaLink}>
+              <Button size="lg" variant="outline">{content.heroSecondaryCta}</Button>
             </Link>
           </div>
         </Container>
@@ -41,34 +94,15 @@ export default function HomePage() {
         <Container>
           <div className="text-center mb-16">
             <h2 className="text-heading-1 font-serif text-neutral-900 mb-4">
-              Why Collectors Choose ArtSpot
+              {content.featuresHeadline}
             </h2>
             <p className="text-body-lg text-neutral-600 max-w-2xl mx-auto">
-              A premium platform designed for serious art collectors
+              {content.featuresSubtitle}
             </p>
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-12">
-            {[
-              {
-                icon: '🎨',
-                title: 'Curated Selection',
-                description:
-                  'Every artwork is carefully selected by our team of art experts guided by institutional standards.',
-              },
-              {
-                icon: '✓',
-                title: 'Authenticity Guaranteed',
-                description:
-                  'Certificates of authenticity and provenance for all works based on honesty and trust.',
-              },
-              {
-                icon: '🤝',
-                title: 'Collector Services',
-                description:
-                  'Personalized assistance and art advisory services for discerning collectors.',
-              },
-            ].map((feature) => (
+            {features.map((feature: any) => (
               <div key={feature.title} className="text-center space-y-4">
                 <div className="w-16 h-16 rounded-full bg-primary-100 flex items-center justify-center mx-auto">
                   <span className="text-2xl">{feature.icon}</span>

--- a/apps/web/components/layout/footer.tsx
+++ b/apps/web/components/layout/footer.tsx
@@ -13,21 +13,15 @@ const navigation = {
   artists: [
     { label: 'Browse All Artists', href: '/artists' },
     { label: 'Featured Artists', href: '/artists/featured' },
-    { label: 'Emerging Artists', href: '/artists/emerging' },
     { label: 'Collections', href: '/collections' },
   ],
   services: [
-    { label: 'Art Advisory', href: '/services/advisory' },
-    { label: 'Authentication', href: '/services/authentication' },
-    { label: 'Insurance', href: '/services/insurance' },
-    { label: 'White-Glove Shipping', href: '/services/shipping' },
-    { label: 'Consignment', href: '/services/consignment' },
+    { label: 'Collector Services', href: '/collector-services' },
+    { label: 'Contact Us', href: '/contact' },
   ],
   company: [
-    { label: 'About ArtSpot', href: '/about' },
-    { label: 'Contact', href: '/contact' },
-    { label: 'Press', href: '/press' },
-    { label: 'Careers', href: '/careers' },
+    { label: 'Discover', href: '/discover' },
+    { label: 'Editorial', href: '/discover/editorial' },
   ],
 };
 
@@ -142,17 +136,6 @@ export function Footer() {
             <p className="text-xs text-neutral-500">
               &copy; {new Date().getFullYear()} ArtSpot. All rights reserved.
             </p>
-            <div className="flex items-center gap-6">
-              <Link href="/privacy" className="text-xs text-neutral-500 hover:text-neutral-300 transition-colors">
-                Privacy Policy
-              </Link>
-              <Link href="/terms" className="text-xs text-neutral-500 hover:text-neutral-300 transition-colors">
-                Terms of Service
-              </Link>
-              <Link href="/cookies" className="text-xs text-neutral-500 hover:text-neutral-300 transition-colors">
-                Cookie Policy
-              </Link>
-            </div>
           </div>
         </Container>
       </div>

--- a/apps/web/components/layout/header.tsx
+++ b/apps/web/components/layout/header.tsx
@@ -10,7 +10,6 @@ import {
   X,
   Search,
   Heart,
-  ShoppingBag,
   User,
   ChevronDown,
   LogOut,
@@ -229,18 +228,6 @@ export function Header({ className }: HeaderProps) {
               aria-label="Favorites"
             >
               <Heart className="h-5 w-5" aria-hidden="true" />
-            </Link>
-
-            {/* Cart */}
-            <Link
-              href="/cart"
-              className="hidden sm:flex relative p-2 text-neutral-700 hover:text-neutral-900 transition-colors"
-              aria-label="Shopping cart"
-            >
-              <ShoppingBag className="h-5 w-5" aria-hidden="true" />
-              <span className="absolute -top-1 -right-1 flex h-5 w-5 items-center justify-center rounded-full bg-primary-500 text-[10px] font-medium text-white" aria-hidden="true">
-                0
-              </span>
             </Link>
 
             {/* Account */}

--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -213,6 +213,14 @@ export interface Article {
   updatedAt: string;
 }
 
+export interface PageContent {
+  id: string;
+  slug: string;
+  content: Record<string, any>;
+  updatedAt: string;
+  createdAt: string;
+}
+
 export interface ArticleFilters {
   category?: ArticleCategory;
   search?: string;
@@ -463,6 +471,15 @@ class ApiClient {
    */
   async getArticle(slug: string): Promise<ApiResponse<Article>> {
     return this.fetch<Article>(`/articles/${slug}`);
+  }
+
+  // ── Page Content ──────────────────────────────────────────────────────
+
+  /**
+   * Get CMS page content by slug
+   */
+  async getPageContent(slug: string): Promise<ApiResponse<PageContent>> {
+    return this.fetch<PageContent>(`/pages/${slug}`);
   }
 }
 


### PR DESCRIPTION
## Summary
- **CMS-driven content**: Add `PageContent` Prisma model + 4 Strapi single types (home, contact, collector-services, discover) so all page copy is editable from the CMS admin
- **API layer**: Webhook sync handler for page single types + `GET /pages/:slug` REST endpoint with fallback defaults
- **9 new pages**: `/contact`, `/collector-services`, `/discover`, `/discover/inspiration`, `/discover/exhibitions`, `/artists/featured`, `/collections/new-arrivals`, `/collections/museum-quality`, `/account`
- **Navigation cleanup**: Remove cart link from header, fix all ~20 broken footer links (removed dead routes to `/services/*`, `/about`, `/press`, `/careers`, `/privacy`, `/terms`, `/cookies`)

## Files changed (35)
- **7 modified**: Prisma schema, API app.ts, cms-sync service, api-client, home page, header, footer
- **16 created (CMS)**: 4 single types × 4 files each (schema.json, controller, route, service)
- **3 created (API)**: page-content service, controller, route
- **9 created (Web)**: New page components

## Test plan
- [ ] Navigate every header link — no 404s
- [ ] Navigate every footer link — no 404s
- [ ] `/contact` renders contact form + info with CMS fallback defaults
- [ ] `/collector-services` renders service cards with CMS fallback defaults
- [ ] `/discover` shows section cards + featured articles
- [ ] `/discover/inspiration` filters articles by BEHIND_THE_SCENES
- [ ] `/discover/exhibitions` filters articles by EXHIBITION
- [ ] `/artists/featured` shows only featured artists
- [ ] `/collections/new-arrivals` shows collections sorted by newest
- [ ] `/collections/museum-quality` shows featured collections
- [ ] `/account` shows profile for logged-in users, sign-in prompt for guests
- [ ] Home page renders with hardcoded defaults when CMS is unreachable
- [ ] Edit home page in Strapi admin → webhook fires → home page shows updated copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)